### PR TITLE
Implement missing config options.

### DIFF
--- a/src/main/java/world/bentobox/level/listeners/NewIslandListener.java
+++ b/src/main/java/world/bentobox/level/listeners/NewIslandListener.java
@@ -11,7 +11,6 @@ import world.bentobox.level.Level;
 import world.bentobox.level.calculators.CalcIslandLevel;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandCreatedEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandResettedEvent;
-import world.bentobox.bentobox.api.events.team.TeamEvent.TeamJoinEvent;
 import world.bentobox.bentobox.database.objects.Island;
 
 /**
@@ -41,24 +40,6 @@ public class NewIslandListener implements Listener {
     public void onNewIsland(IslandResettedEvent e) {
         cil.putIfAbsent(e.getIsland(), new CalcIslandLevel(addon, e.getIsland(), () -> zeroLevel(e.getIsland())));
     }
-
-
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onTeamJoin(TeamJoinEvent event)
-    {
-        if (this.addon.getSettings().isTeamJoinDeathReset())
-        {
-            this.cil.putIfAbsent(event.getIsland(),
-                new CalcIslandLevel(this.addon,
-                    event.getIsland(),
-                    () -> zeroLevel(event.getIsland())));
-
-            this.addon.getPlayers().setDeaths(event.getIsland().getWorld(),
-                event.getOwner(),
-                0);
-        }
-    }
-
 
     private void zeroLevel(Island island) {
         if (cil.containsKey(island)) {

--- a/src/main/java/world/bentobox/level/listeners/NewIslandListener.java
+++ b/src/main/java/world/bentobox/level/listeners/NewIslandListener.java
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener;
 
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandCreatedEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandResettedEvent;
+import world.bentobox.bentobox.api.events.team.TeamEvent.TeamJoinEvent;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.level.Level;
 import world.bentobox.level.calculators.CalcIslandLevel;
@@ -46,6 +47,24 @@ public class NewIslandListener implements Listener {
             addon.getPlayers().setDeaths(e.getIsland().getWorld(), e.getOwner(), 0);
         }
     }
+
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onTeamJoin(TeamJoinEvent event)
+    {
+        if (this.addon.getSettings().isTeamJoinDeathReset())
+        {
+            this.cil.putIfAbsent(event.getIsland(),
+                new CalcIslandLevel(this.addon,
+                    event.getIsland(),
+                    () -> zeroLevel(event.getIsland())));
+
+            this.addon.getPlayers().setDeaths(event.getIsland().getWorld(),
+                event.getOwner(),
+                0);
+        }
+    }
+
 
     private void zeroLevel(Island island) {
         if (cil.containsKey(island)) {


### PR DESCRIPTION
In this PR I add missing config option usage.

I implement sumTeamDeaths, maxDeaths and deathPenalty options.
It was necessary to change level calculation. Now it will calculate deathHandicap based on sumTeamDeaths and maxDeaths values. To implement deathPenalty I introduce a local variable that is calculated based on rawBlockCount and deathPenalty and use this variable to calculate level and points till next level.

