### PR TITLE
Add TopTenRequestHandler (#46)

### DIFF
--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -22,6 +22,8 @@ import world.bentobox.level.placeholders.LevelPlaceholder;
 import world.bentobox.level.placeholders.TopTenNamePlaceholder;
 import world.bentobox.level.placeholders.TopTenPlaceholder;
 import world.bentobox.level.requests.LevelRequestHandler;
+import world.bentobox.level.requests.TopTenRequestHandler;
+
 
 /**
  * Addon to BSkyBlock/AcidIsland that enables island level scoring and top ten functionality
@@ -146,6 +148,7 @@ public class Level extends Addon {
 
         // Register request handlers
         registerRequestHandler(new LevelRequestHandler(this));
+        registerRequestHandler(new TopTenRequestHandler(this));
 
         // Done
     }

--- a/src/main/java/world/bentobox/level/requests/TopTenRequestHandler.java
+++ b/src/main/java/world/bentobox/level/requests/TopTenRequestHandler.java
@@ -1,0 +1,60 @@
+package world.bentobox.level.requests;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.bukkit.Bukkit;
+
+import world.bentobox.bentobox.api.addons.request.AddonRequestHandler;
+import world.bentobox.level.Level;
+import world.bentobox.level.objects.TopTenData;
+
+
+/**
+ * This Request Handler allows other plugins to get access to top 10 player list per particular world.
+ * Handler returns linked hashmap from TopTenData for particular world.
+ */
+public class TopTenRequestHandler extends AddonRequestHandler {
+
+	/**
+	 * The level addon field.
+	 */
+	private Level addon;
+
+	/**
+	 * This constructor creates a new TopTenRequestHandler instance.
+	 *
+	 * @param addon of type Level
+	 */
+	public TopTenRequestHandler(Level addon) {
+		super("top-ten-level");
+		this.addon = addon;
+	}
+
+	/**
+	 * @see AddonRequestHandler#handle(Map<String, Object>)
+	 */
+	@Override
+	public Object handle(Map<String, Object> map) {
+        /*
+            What we need in the map:
+
+            "world-name" -> String
+
+            What we will return:
+
+            - Empty map if invalid input
+            - the map of top ten player UUIDs and their island levels. Can be less then 10.
+         */
+
+		if (map == null || map.isEmpty()
+			|| map.get("world-name") == null || !(map.get("world-name") instanceof String)
+			|| Bukkit.getWorld((String) map.get("world-name")) == null) {
+			return Collections.emptyMap();
+		}
+
+		// Null-point check.
+		TopTenData data = addon.getTopTen().getTopTenList(Bukkit.getWorld((String) map.get("world-name")));
+		return data != null ? data.getTopTen() : Collections.emptyMap();
+	}
+}


### PR DESCRIPTION
Add new data Request Handler for Level add-on, which requires world-name in input and returns:
- empty map, if input is invalid
- LinkedHashMap from TopTenData object for given world.