### PR TITLE
Added island name to gui-heading

### DIFF
--- a/src/main/java/world/bentobox/level/TopTen.java
+++ b/src/main/java/world/bentobox/level/TopTen.java
@@ -126,23 +126,26 @@ public class TopTen implements Listener {
      * @return PanelItem
      */
     private PanelItem getHead(int rank, long level, UUID playerUUID, User asker, World world) {
-        String playerName = addon.getPlayers().getName(playerUUID);            
-        String name = addon.getIslands().getIsland(world, playerUUID).getName();
+        String playerName = addon.getPlayers().getName(playerUUID);
+        String name = "";
+        if (addon.getIslands().hasIsland(world, playerUUID)) {
+            name = addon.getIslands().getIsland(world, playerUUID).getName();
+        }         
         if (name == null) {
-               name = playerName;
+            name = playerName;
         }    
         name = asker.getTranslation("island.top.gui-heading", "[name]", name, "[rank]", String.valueOf(rank));        
         List<String> description = new ArrayList<>();
-        if (name != null) {          
-            description.add(asker.getTranslation("island.top.island-level","[level]", addon.getLevelPresenter().getLevelString(level)));
-            if (addon.getIslands().inTeam(world, playerUUID)) {
-                List<String> memberList = new ArrayList<>();
-                for (UUID members : addon.getIslands().getMembers(world, playerUUID)) {
-                    memberList.add(ChatColor.AQUA + addon.getPlayers().getName(members));
-                }
-                description.addAll(memberList);
+       
+        description.add(asker.getTranslation("island.top.island-level","[level]", addon.getLevelPresenter().getLevelString(level)));
+        if (addon.getIslands().inTeam(world, playerUUID)) {
+            List<String> memberList = new ArrayList<>();
+            for (UUID members : addon.getIslands().getMembers(world, playerUUID)) {
+                memberList.add(ChatColor.AQUA + addon.getPlayers().getName(members));
             }
+            description.addAll(memberList);
         }
+        
         PanelItemBuilder builder = new PanelItemBuilder()
                 .icon(playerName)
                 .name(name)

--- a/src/main/java/world/bentobox/level/TopTen.java
+++ b/src/main/java/world/bentobox/level/TopTen.java
@@ -126,10 +126,14 @@ public class TopTen implements Listener {
      * @return PanelItem
      */
     private PanelItem getHead(int rank, long level, UUID playerUUID, User asker, World world) {
-        final String name = addon.getPlayers().getName(playerUUID);
+        String playerName = addon.getPlayers().getName(playerUUID);            
+        String name = addon.getIslands().getIsland(world, playerUUID).getName();
+        if (name == null) {
+               name = playerName;
+        }    
+        name = asker.getTranslation("island.top.gui-heading", "[name]", name, "[rank]", String.valueOf(rank));        
         List<String> description = new ArrayList<>();
-        if (name != null) {
-            description.add(asker.getTranslation("island.top.gui-heading", "[name]", name, "[rank]", String.valueOf(rank)));
+        if (name != null) {          
             description.add(asker.getTranslation("island.top.island-level","[level]", addon.getLevelPresenter().getLevelString(level)));
             if (addon.getIslands().inTeam(world, playerUUID)) {
                 List<String> memberList = new ArrayList<>();
@@ -140,7 +144,7 @@ public class TopTen implements Listener {
             }
         }
         PanelItemBuilder builder = new PanelItemBuilder()
-                .icon(name)
+                .icon(playerName)
                 .name(name)
                 .description(description);
         return builder.build();


### PR DESCRIPTION
- The gui-heading is now shown on the item name instead of in the description.
- The default [name] is now the island name. If not set, use the player name.

I noticed something wrong was with the current gui when the owner name was 3 times in the item (name of the item, first line of description and list of members). Now if the island has name, the owner will only appear once (in the member list).