### PR TITLE
add throttle to calculate chunks

### DIFF
--- a/src/main/java/world/bentobox/level/calculators/CalcIslandLevel.java
+++ b/src/main/java/world/bentobox/level/calculators/CalcIslandLevel.java
@@ -107,7 +107,7 @@ public class CalcIslandLevel {
 
     }
 
-    private synchronized void addChunkQueue(Chunk ch) {
+    private void addChunkQueue(Chunk ch) {
         q.add(ch);
     }
 


### PR DESCRIPTION
island level takes a few seconds longer, but for example a 400 size island can cause a lot of thrashing from all the tasks created per chunk, this slows it down so there is no overload of the machine

timings before: https://timings.aikar.co/?id=a72e74a387854e599e0c9e2c6c22bc52

timings after: https://timings.aikar.co/?id=20ba5c0493bf4387aa7ee7d0b73fe77b