### PR TITLE
Island levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>2.3.4</build.version>
+        <build.version>2.4.0</build.version>
     </properties>
 
     <!-- Profiles will allow to automatically change build version. -->

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -30,7 +30,6 @@ import world.bentobox.level.config.BlockConfig;
 import world.bentobox.level.config.ConfigSettings;
 import world.bentobox.level.listeners.IslandActivitiesListeners;
 import world.bentobox.level.listeners.JoinLeaveListener;
-import world.bentobox.level.objects.LevelsData;
 import world.bentobox.level.requests.LevelRequestHandler;
 import world.bentobox.level.requests.TopTenRequestHandler;
 
@@ -119,8 +118,8 @@ public class Level extends Addon implements Listener {
 
             getIslands().getIslands().stream().filter(Island::isOwned).forEach(is -> {
 
-                this.getManager().calculateLevel(is.getOwner(), is).thenAccept(r -> 
-                log("Result for island calc " + r.getLevel() + " at " + is.getCenter())); 
+                this.getManager().calculateLevel(is.getOwner(), is).thenAccept(r ->
+                log("Result for island calc " + r.getLevel() + " at " + is.getCenter()));
 
             });
        }, 60L);*/
@@ -319,12 +318,4 @@ public class Level extends Addon implements Listener {
         if (island != null) getManager().calculateLevel(playerUUID, island);
     }
 
-    /**
-     * Load a player from the cache or database
-     * @param targetPlayer - UUID of target player
-     * @return LevelsData object or null if not found
-     */
-    public LevelsData getLevelsData(UUID targetPlayer) {
-        return getManager().getLevelsData(targetPlayer);
-    }
 }

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -100,7 +100,7 @@ public class Level extends Addon implements Listener {
     @EventHandler
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
         // Perform upgrade check
-        manager.migrate(this);
+        manager.migrate();
         // Load TopTens
         manager.loadTopTens();
         /*

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -98,6 +98,9 @@ public class Level extends Addon implements Listener {
 
     @EventHandler
     public void onBentoBoxReady(BentoBoxReadyEvent e) {
+        // Perform upgrade check
+        manager.migrate(this);
+        // Load TopTens
         manager.loadTopTens();
         /*
          * DEBUG code to generate fake islands and then try to level them all.

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -22,6 +22,7 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.level.calculators.Pipeliner;
 import world.bentobox.level.commands.AdminLevelCommand;
 import world.bentobox.level.commands.AdminLevelStatusCommand;
+import world.bentobox.level.commands.AdminSetInitialLevelCommand;
 import world.bentobox.level.commands.AdminTopCommand;
 import world.bentobox.level.commands.IslandLevelCommand;
 import world.bentobox.level.commands.IslandTopCommand;
@@ -189,6 +190,7 @@ public class Level extends Addon implements Listener {
             new AdminLevelCommand(this, adminCommand);
             new AdminTopCommand(this, adminCommand);
             new AdminLevelStatusCommand(this, adminCommand);
+            new AdminSetInitialLevelCommand(this, adminCommand);
         });
         gm.getPlayerCommand().ifPresent(playerCmd -> {
             new IslandLevelCommand(this, playerCmd);

--- a/src/main/java/world/bentobox/level/LevelsManager.java
+++ b/src/main/java/world/bentobox/level/LevelsManager.java
@@ -87,7 +87,7 @@ public class LevelsManager {
         background = new PanelItemBuilder().icon(Material.BLACK_STAINED_GLASS_PANE).name(" ").build();
     }
 
-    public void migrate(Level addon2) {
+    public void migrate() {
         Database<LevelsData> oldDb = new Database<>(addon, LevelsData.class);
         oldDb.loadObjects().forEach(ld -> {
             try {
@@ -323,9 +323,7 @@ public class LevelsManager {
      * @return initial level of island
      */
     public long getInitialLevel(Island island) {
-        @Nullable
-        IslandLevels ld = getLevelsData(island);
-        return ld == null ? 0 : ld.getInitialLevel();
+        return getLevelsData(island).getInitialLevel();
     }
 
     /**

--- a/src/main/java/world/bentobox/level/commands/AdminSetInitialLevelCommand.java
+++ b/src/main/java/world/bentobox/level/commands/AdminSetInitialLevelCommand.java
@@ -1,0 +1,80 @@
+package world.bentobox.level.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.localization.TextVariables;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+import world.bentobox.level.Level;
+
+public class AdminSetInitialLevelCommand extends CompositeCommand {
+
+    private @Nullable UUID targetUUID;
+    private @Nullable Island island;
+    private Level addon;
+
+    public AdminSetInitialLevelCommand(Level addon, CompositeCommand parent) {
+        super(parent, "sethandicap");
+        this.addon = addon;
+    }
+
+    @Override
+    public void setup() {
+        this.setPermission("admin.level.sethandicap");
+        this.setOnlyPlayer(false);
+        this.setParametersHelp("admin.level.sethandicap.parameters");
+        this.setDescription("admin.level.sethandicap.description");
+    }
+
+    @Override
+    public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
+        String lastArg = !args.isEmpty() ? args.get(args.size()-1) : "";
+        if (args.isEmpty()) {
+            // Don't show every player on the server. Require at least the first letter
+            return Optional.empty();
+        }
+        List<String> options = new ArrayList<>(Util.getOnlinePlayerList(user));
+        return Optional.of(Util.tabLimit(options, lastArg));
+    }
+
+    @Override
+    public boolean execute(User user, String label, List<String> args) {
+        String initialLevel = String.valueOf(addon.getManager().getInitialLevel(island));
+        long lv = Long.valueOf(args.get(1));
+        addon.getManager().setInitialIslandLevel(island, lv);
+        user.sendMessage("admin.level.sethandicap.changed", TextVariables.NUMBER, initialLevel, "[new_number]", String.valueOf(lv));
+        return true;
+    }
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args) {
+        if (args.size() != 2) {
+            showHelp(this, user);
+            return false;
+        }
+        targetUUID = getAddon().getPlayers().getUUID(args.get(0));
+        if (targetUUID == null) {
+            user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
+            return false;
+        }
+        // Check value
+        if (!Util.isInteger(args.get(1), true)) {
+            user.sendMessage("admin.level.sethandicap.invalid-level");
+            return false;
+        }
+        // Check island
+        island = getAddon().getIslands().getIsland(getWorld(), targetUUID);
+        if (island == null) {
+            user.sendMessage("general.errors.player-has-no-island");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/world/bentobox/level/commands/AdminSetInitialLevelCommand.java
+++ b/src/main/java/world/bentobox/level/commands/AdminSetInitialLevelCommand.java
@@ -47,7 +47,7 @@ public class AdminSetInitialLevelCommand extends CompositeCommand {
     @Override
     public boolean execute(User user, String label, List<String> args) {
         String initialLevel = String.valueOf(addon.getManager().getInitialLevel(island));
-        long lv = Long.valueOf(args.get(1));
+        long lv = Long.parseLong(args.get(1));
         addon.getManager().setInitialIslandLevel(island, lv);
         user.sendMessage("admin.level.sethandicap.changed", TextVariables.NUMBER, initialLevel, "[new_number]", String.valueOf(lv));
         return true;

--- a/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
@@ -38,7 +38,7 @@ public class IslandLevelCommand extends CompositeCommand {
             final UUID playerUUID = getPlugin().getPlayers().getUUID(args.get(0));
             if (playerUUID == null) {
                 user.sendMessage("general.errors.unknown-player", TextVariables.NAME, args.get(0));
-                return true;
+                return false;
             }
             // Ops, console and admin perms can request and calculate other player levels
             if (!user.isPlayer() || user.isOp() || user.hasPermission(this.getPermissionPrefix() + "admin.level")) {

--- a/src/main/java/world/bentobox/level/listeners/IslandActivitiesListeners.java
+++ b/src/main/java/world/bentobox/level/listeners/IslandActivitiesListeners.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandCreatedEvent;
+import world.bentobox.bentobox.api.events.island.IslandEvent.IslandDeleteEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandPreclearEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandRegisteredEvent;
 import world.bentobox.bentobox.api.events.island.IslandEvent.IslandResettedEvent;
@@ -65,6 +66,12 @@ public class IslandActivitiesListeners implements Listener {
         remove(world, uuid);
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onIslandDeleted(IslandDeleteEvent e) {
+        // Remove island
+        addon.getManager().deleteIsland(e.getIsland().getUniqueId());
+    }
+
     private void remove(World world, UUID uuid) {
         if (uuid != null && world != null) {
             addon.getManager().removeEntry(world, uuid);
@@ -88,14 +95,14 @@ public class IslandActivitiesListeners implements Listener {
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onIsland(IslandUnregisteredEvent e) {
 
-        // Remove player from the top ten and level
+        // Remove player from the top ten
         remove(e.getIsland().getWorld(), e.getPlayerUUID());
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onIsland(IslandRegisteredEvent e) {
 
-        // Remove player from the top ten and level
+        // Remove player from the top ten
         remove(e.getIsland().getWorld(), e.getPlayerUUID());
     }
 

--- a/src/main/java/world/bentobox/level/listeners/JoinLeaveListener.java
+++ b/src/main/java/world/bentobox/level/listeners/JoinLeaveListener.java
@@ -27,8 +27,6 @@ public class JoinLeaveListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerJoin(PlayerJoinEvent e) {
-        // Load player into cache
-        addon.getManager().getLevelsData(e.getPlayer().getUniqueId());
         // If level calc on login is enabled, run through all the worlds and calculate the level
         if (addon.getSettings().isCalcOnLogin()) {
             addon.getPlugin().getAddonsManager().getGameModeAddons().stream()

--- a/src/main/java/world/bentobox/level/objects/IslandLevels.java
+++ b/src/main/java/world/bentobox/level/objects/IslandLevels.java
@@ -1,0 +1,156 @@
+package world.bentobox.level.objects;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Material;
+
+import com.google.gson.annotations.Expose;
+
+import world.bentobox.bentobox.database.objects.DataObject;
+import world.bentobox.bentobox.database.objects.Table;
+
+/**
+ * Stores the levels data of the island.
+ * A note - if this class is extended to support new exposed fields and legacy data doesn't include those fields
+ * they will be set to null by GSON. They will not be initialized and if any attempt is made to use them, then
+ * the JVM will give up WITHOUT AN ERROR!!! That is why there are null checks throughout this class.
+ *
+ * @author tastybento
+ *
+ */
+@Table(name = "IslandLevels")
+public class IslandLevels implements DataObject {
+
+    // uniqueId is the island's UUID
+    @Expose
+    private String uniqueId = "";
+
+    /**
+     * Island level
+     */
+    @Expose
+    private long level;
+    /**
+     * Initial level
+     */
+    @Expose
+    private long initialLevel;
+    /**
+     * Points to next level
+     */
+    @Expose
+    private long pointsToNextLevel;
+
+    /**
+     * Underwater count
+     */
+    @Expose
+    private Map<Material, Integer> uwCount;
+
+    /**
+     * MaterialData count - count of all blocks
+     */
+    @Expose
+    private Map<Material, Integer> mdCount;
+
+    /**
+     * Constructor for new island
+     * @param islandUUID - island UUID
+     */
+    public IslandLevels(String islandUUID) {
+        uniqueId = islandUUID;
+        uwCount = new HashMap<>();
+        mdCount = new HashMap<>();
+    }
+
+    /**
+     * @return the uniqueId
+     */
+    @Override
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
+    /**
+     * @param uniqueId the uniqueId to set
+     */
+    @Override
+    public void setUniqueId(String uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+
+    /**
+     * @return the level
+     */
+    public long getLevel() {
+        return level;
+    }
+
+    /**
+     * @param level the level to set
+     */
+    public void setLevel(long level) {
+        this.level = level;
+    }
+
+    /**
+     * @return the initialLevel
+     */
+    public long getInitialLevel() {
+        return initialLevel;
+    }
+
+    /**
+     * @param initialLevel the initialLevel to set
+     */
+    public void setInitialLevel(long initialLevel) {
+        this.initialLevel = initialLevel;
+    }
+
+    /**
+     * @return the pointsToNextLevel
+     */
+    public long getPointsToNextLevel() {
+        return pointsToNextLevel;
+    }
+
+    /**
+     * @param pointsToNextLevel the pointsToNextLevel to set
+     */
+    public void setPointsToNextLevel(long pointsToNextLevel) {
+        this.pointsToNextLevel = pointsToNextLevel;
+    }
+
+    /**
+     * @return the uwCount
+     */
+    public Map<Material, Integer> getUwCount() {
+        return uwCount;
+    }
+
+    /**
+     * @param uwCount the uwCount to set
+     */
+    public void setUwCount(Map<Material, Integer> uwCount) {
+        this.uwCount = uwCount;
+    }
+
+    /**
+     * @return the mdCount
+     */
+    public Map<Material, Integer> getMdCount() {
+        return mdCount;
+    }
+
+    /**
+     * @param mdCount the mdCount to set
+     */
+    public void setMdCount(Map<Material, Integer> mdCount) {
+        this.mdCount = mdCount;
+    }
+
+
+
+
+}

--- a/src/main/java/world/bentobox/level/objects/IslandLevels.java
+++ b/src/main/java/world/bentobox/level/objects/IslandLevels.java
@@ -1,6 +1,6 @@
 package world.bentobox.level.objects;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.bukkit.Material;
@@ -60,8 +60,8 @@ public class IslandLevels implements DataObject {
      */
     public IslandLevels(String islandUUID) {
         uniqueId = islandUUID;
-        uwCount = new HashMap<>();
-        mdCount = new HashMap<>();
+        uwCount = new EnumMap<>(Material.class);
+        mdCount = new EnumMap<>(Material.class);
     }
 
     /**
@@ -149,8 +149,6 @@ public class IslandLevels implements DataObject {
     public void setMdCount(Map<Material, Integer> mdCount) {
         this.mdCount = mdCount;
     }
-
-
 
 
 }

--- a/src/main/java/world/bentobox/level/panels/DetailsGUITab.java
+++ b/src/main/java/world/bentobox/level/panels/DetailsGUITab.java
@@ -27,7 +27,7 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.level.Level;
-import world.bentobox.level.objects.LevelsData;
+import world.bentobox.level.objects.IslandLevels;
 
 /**
  * @author tastybento
@@ -131,20 +131,20 @@ public class DetailsGUITab implements Tab, ClickHandler {
 
     private void generateReport(DetailsType type) {
         items = new ArrayList<>();
-        LevelsData ld = addon.getManager().getLevelsData(island.getOwner());
+        IslandLevels ld = addon.getManager().getLevelsData(island);
         // Get the items from the report
         Map<Material, Integer> sumTotal = new EnumMap<>(Material.class);
-        sumTotal.putAll(ld.getMdCount(world));
-        sumTotal.putAll(ld.getUwCount(world));
+        sumTotal.putAll(ld.getMdCount());
+        sumTotal.putAll(ld.getUwCount());
         switch(type) {
         case ABOVE_SEA_LEVEL_BLOCKS:
-            ld.getMdCount(world).forEach(this::createItem);
+            ld.getMdCount().forEach(this::createItem);
             break;
         case SPAWNERS:
             sumTotal.entrySet().stream().filter(m -> m.getKey().equals(Material.SPAWNER)).forEach(e -> createItem(e.getKey(), e.getValue()));
             break;
         case UNDERWATER_BLOCKS:
-            ld.getUwCount(world).forEach(this::createItem);
+            ld.getUwCount().forEach(this::createItem);
             break;
         default:
             sumTotal.forEach(this::createItem);

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -7,6 +7,11 @@ admin:
   level:
     parameters: "<player>"
     description: "calculate the island level for player"
+    sethandicap:
+      parameters: <player> <handicap>
+      description: "set the island handicap, usually the level of the starter island"
+      changed: "&a Initial island handicap changed from [number] to [new_number]."
+      invalid-level: "&c Invalid handicap. Use an integer."
   levelstatus:
     description: "show how many islands are in the queue for scanning"
     islands-in-queue: "&a Islands in queue: [number]"
@@ -17,6 +22,7 @@ admin:
     remove:
       description: "remove player from Top Ten"
       parameters: "<player>"
+
 
 island:
   level: 

--- a/src/test/java/world/bentobox/level/LevelTest.java
+++ b/src/test/java/world/bentobox/level/LevelTest.java
@@ -275,8 +275,8 @@ public class LevelTest {
         addon.onEnable();
         verify(plugin).logWarning("[Level] Level Addon: No such world in blockconfig.yml : acidisland_world");
         verify(plugin).log("[Level] Level hooking into BSkyBlock");
-        verify(cmd, times(3)).getAddon(); // Three commands
-        verify(adminCmd, times(3)).getAddon(); // Three commands
+        verify(cmd, times(3)).getAddon(); // 3 commands
+        verify(adminCmd, times(4)).getAddon(); // Four commands
         // Placeholders
         verify(phm).registerPlaceholder(eq(addon), eq("bskyblock_island_level"), any());
         verify(phm).registerPlaceholder(eq(addon), eq("bskyblock_visited_island_level"), any());

--- a/src/test/java/world/bentobox/level/LevelsManagerTest.java
+++ b/src/test/java/world/bentobox/level/LevelsManagerTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +59,7 @@ import world.bentobox.bentobox.managers.PlayersManager;
 import world.bentobox.level.calculators.Pipeliner;
 import world.bentobox.level.calculators.Results;
 import world.bentobox.level.config.ConfigSettings;
-import world.bentobox.level.objects.LevelsData;
+import world.bentobox.level.objects.IslandLevels;
 import world.bentobox.level.objects.TopTenData;
 
 /**
@@ -104,7 +105,7 @@ public class LevelsManagerTest {
     @Mock
     private PluginManager pim;
     @Mock
-    private LevelsData levelsData;
+    private IslandLevels levelsData;
     @Mock
     private IslandsManager im;
 
@@ -125,6 +126,7 @@ public class LevelsManagerTest {
     /**
      * @throws java.lang.Exception
      */
+    @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
         when(addon.getPlugin()).thenReturn(plugin);
@@ -154,9 +156,11 @@ public class LevelsManagerTest {
         when(island.getMemberSet()).thenReturn(iset);
         when(island.getOwner()).thenReturn(uuid);
         when(island.getWorld()).thenReturn(world);
+        when(island.getUniqueId()).thenReturn(UUID.randomUUID().toString());
         // Default to uuid's being island owners
         when(im.isOwner(eq(world), any())).thenReturn(true);
         when(im.getOwner(any(), any(UUID.class))).thenAnswer(in -> in.getArgument(1, UUID.class));
+        when(im.getIsland(eq(world), eq(uuid))).thenReturn(island);
 
         // Player
         when(player.getUniqueId()).thenReturn(uuid);
@@ -205,9 +209,10 @@ public class LevelsManagerTest {
         // Include a known UUID
         ttd.getTopTen().put(uuid, 456789L);
         topTen.add(ttd);
-        when(handler.loadObjects()).thenReturn(topTen);
+        // Supply no island levels first, then topTen
+        when(handler.loadObjects()).thenReturn(Collections.emptyList(), topTen);
         when(handler.objectExists(anyString())).thenReturn(true);
-        when(levelsData.getLevel(any())).thenReturn(-5L, -4L, -3L, -2L, -1L, 0L, 1L, 2L, 3L, 4L, 5L, 45678L);
+        when(levelsData.getLevel()).thenReturn(-5L, -4L, -3L, -2L, -1L, 0L, 1L, 2L, 3L, 4L, 5L, 45678L);
         when(levelsData.getUniqueId()).thenReturn(uuid.toString());
         when(handler.loadObject(anyString())).thenReturn(levelsData );
 
@@ -220,6 +225,7 @@ public class LevelsManagerTest {
         when(iwm.getPermissionPrefix(any())).thenReturn("bskyblock.");
 
         lm = new LevelsManager(addon);
+        lm.migrate(addon);
     }
 
     /**
@@ -252,7 +258,7 @@ public class LevelsManagerTest {
         lm.calculateLevel(uuid, island);
         cf.complete(results);
 
-        assertEquals(Long.valueOf(10000), lm.getLevelsData(uuid).getLevel(world));
+        assertEquals(10000L, lm.getLevelsData(island).getLevel());
         //Map<UUID, Long> tt = lm.getTopTen(world, 10);
         //assertEquals(1, tt.size());
         //assertTrue(tt.get(uuid) == 10000);
@@ -280,7 +286,9 @@ public class LevelsManagerTest {
      */
     @Test
     public void testGetPointsToNextString() {
-        assertEquals("0", lm.getPointsToNextString(world, UUID.randomUUID()));
+        // No island player
+        assertEquals("", lm.getPointsToNextString(world, UUID.randomUUID()));
+        // Player has island
         assertEquals("0", lm.getPointsToNextString(world, uuid));
     }
 
@@ -297,7 +305,7 @@ public class LevelsManagerTest {
      */
     @Test
     public void testGetLevelsData() {
-        assertEquals(levelsData, lm.getLevelsData(uuid));
+        assertEquals(levelsData, lm.getLevelsData(island));
 
     }
 

--- a/src/test/java/world/bentobox/level/LevelsManagerTest.java
+++ b/src/test/java/world/bentobox/level/LevelsManagerTest.java
@@ -225,7 +225,7 @@ public class LevelsManagerTest {
         when(iwm.getPermissionPrefix(any())).thenReturn("bskyblock.");
 
         lm = new LevelsManager(addon);
-        lm.migrate(addon);
+        lm.migrate();
     }
 
     /**


### PR DESCRIPTION
Levels are now stored as islands and not players. This is much more logical. It also means the original island level will persist between players who become owners and also if the island becomes unregistered and then registered again.

Fixes #177 
Fixes #90 
