### PR TITLE
Fix Level not loading after recent change

### DIFF
--- a/src/main/java/world/bentobox/level/config/ConfigSettings.java
+++ b/src/main/java/world/bentobox/level/config/ConfigSettings.java
@@ -376,5 +376,13 @@ public class ConfigSettings implements ConfigObject {
     public boolean isLogReportToConsole() {
         return logReportToConsole;
     }
+    
+    
+    /**
+     * @param logReportToConsole if logReportToConsole should be shown on console
+     */
+    public void setLogReportToConsole(boolean logReportToConsole) {
+        this.logReportToConsole = logReportToConsole;
+    }
 
 }


### PR DESCRIPTION
Sorry, I didn't know setters for config options were mandatory. Now working fine.