### PR TITLE
Closes #223 - Add shulker content to in chest count

### DIFF
--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -24,13 +24,11 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
-import org.bukkit.block.Container;
-import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.*;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Slab;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.scheduler.BukkitTask;
 
 import com.bgsoftware.wildstacker.api.WildStackerAPI;
@@ -442,10 +440,16 @@ public class IslandLevelCalculator {
     }
 
     private void countItemStack(ItemStack i) {
-        if (i != null && i.getType().isBlock()) {
-            for (int c = 0; c < i.getAmount(); c++) {
-                checkBlock(i.getType(), false);
+        if (i == null || !i.getType().isBlock()) return;
+
+        for (int c = 0; c < i.getAmount(); c++) {
+            if (addon.getSettings().isIncludeShulkersInChest()
+                    && i.getItemMeta() instanceof BlockStateMeta blockStateMeta
+                    && blockStateMeta.getBlockState() instanceof ShulkerBox shulkerBox) {
+                shulkerBox.getSnapshotInventory().forEach(this::countItemStack);
             }
+
+            checkBlock(i.getType(), false);
         }
     }
 

--- a/src/main/java/world/bentobox/level/config/ConfigSettings.java
+++ b/src/main/java/world/bentobox/level/config/ConfigSettings.java
@@ -119,6 +119,12 @@ public class ConfigSettings implements ConfigObject {
     @ConfigComment("Shows large level values rounded down, e.g., 10,345 -> 10k")
     @ConfigEntry(path = "shorthand")
     private boolean shorthand = false;
+    @ConfigComment("")
+    @ConfigComment("Include Shulker Box content in chests in level calculations.")
+    @ConfigComment("Will count blocks in Shulker Boxes inside of chests.")
+    @ConfigComment("NOTE: include-chests needs to be enabled for this to work!.")
+    @ConfigEntry(path = "include-shulkers-in-chest")
+    private boolean includeShulkersInChest = false;
 
 
     /**
@@ -385,4 +391,17 @@ public class ConfigSettings implements ConfigObject {
         this.logReportToConsole = logReportToConsole;
     }
 
+    /**
+     * @return includeShulkersInChest
+     */
+    public boolean isIncludeShulkersInChest() {
+        return includeShulkersInChest;
+    }
+
+    /**
+     * @param includeShulkersInChest the includeChests to set
+     */
+    public void setIncludeShulkersInChest(boolean includeShulkersInChest) {
+        this.includeShulkersInChest = includeShulkersInChest;
+    }
 }


### PR DESCRIPTION
Closes #223 

Adds the `include-shulkers-in-chest` setting to the config, which allows you to include the contents of a shulkerbox inside a chest in the island level calculation. Default on false to keep it consistent with current situation.

Will need addition to the docs, of which I can make a PR too if requested c:
