### PR TITLE
Add config option to disable plugin hooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>com.songoda</groupId>
             <artifactId>UltimateStacker</artifactId>
-            <version>2.3.3</version>
+            <version>2.4.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -126,32 +126,42 @@ public class Level extends Addon {
         // Check if WildStackers is enabled on the server
         // I only added support for counting blocks into the island level
         // Someone else can PR if they want spawners added to the Leveling system :)
-        stackersEnabled = Bukkit.getPluginManager().isPluginEnabled("WildStacker");
-        if (stackersEnabled) {
-            log("Hooked into WildStackers.");
-        }
-        // Check if AdvancedChests is enabled on the server
-        Plugin advChest = Bukkit.getPluginManager().getPlugin("AdvancedChests");
-        advChestEnabled = advChest != null;
-        if (advChestEnabled) {
-            // Check version
-            if (compareVersions(advChest.getDescription().getVersion(), "23.0") > 0) {
-                log("Hooked into AdvancedChests.");
-            } else {
-                logError("Could not hook into AdvancedChests " + advChest.getDescription().getVersion() + " - requires version 23.0 or later");
-                advChestEnabled = false;
+        if ( !settings.getDisabledPluginHooks().contains("WildStacker") ) {
+            stackersEnabled = Bukkit.getPluginManager().isPluginEnabled("WildStacker");
+            if (stackersEnabled) {
+                log("Hooked into WildStackers.");
             }
         }
+
+        // Check if AdvancedChests is enabled on the server
+        if ( !settings.getDisabledPluginHooks().contains("AdvancedChests") ) {
+            Plugin advChest = Bukkit.getPluginManager().getPlugin("AdvancedChests");
+            advChestEnabled = advChest != null;
+            if (advChestEnabled) {
+                // Check version
+                if (compareVersions(advChest.getDescription().getVersion(), "23.0") > 0) {
+                    log("Hooked into AdvancedChests.");
+                } else {
+                    logError("Could not hook into AdvancedChests " + advChest.getDescription().getVersion() + " - requires version 23.0 or later");
+                    advChestEnabled = false;
+                }
+            }
+        }
+
         // Check if RoseStackers is enabled
-        roseStackersEnabled = Bukkit.getPluginManager().isPluginEnabled("RoseStacker");
-        if (roseStackersEnabled) {
-            log("Hooked into RoseStackers.");
+        if ( !settings.getDisabledPluginHooks().contains("RoseStacker") ) {
+            roseStackersEnabled = Bukkit.getPluginManager().isPluginEnabled("RoseStacker");
+            if (roseStackersEnabled) {
+                log("Hooked into RoseStackers.");
+            }
         }
 
         // Check if UltimateStacker is enabled
-        ultimateStackerEnabled = Bukkit.getPluginManager().isPluginEnabled("UltimateStacker");
-        if (ultimateStackerEnabled) {
-            log("Hooked into UltimateStacker.");
+        if ( !settings.getDisabledPluginHooks().contains("UltimateStacker") ) {
+            ultimateStackerEnabled = Bukkit.getPluginManager().isPluginEnabled("UltimateStacker");
+            if (ultimateStackerEnabled) {
+                log("Hooked into UltimateStacker.");
+            }
         }
     }
 

--- a/src/main/java/world/bentobox/level/config/ConfigSettings.java
+++ b/src/main/java/world/bentobox/level/config/ConfigSettings.java
@@ -1,5 +1,6 @@
 package world.bentobox.level.config;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -125,6 +126,12 @@ public class ConfigSettings implements ConfigObject {
     @ConfigComment("NOTE: include-chests needs to be enabled for this to work!.")
     @ConfigEntry(path = "include-shulkers-in-chest")
     private boolean includeShulkersInChest = false;
+
+    @ConfigComment("")
+    @ConfigComment("Disables hooking with other plugins.")
+    @ConfigComment("Example: disabled-plugin-hooks: [UltimateStacker, RoseStacker]")
+    @ConfigEntry(path = "disabled-plugin-hooks")
+    private List<String> disabledPluginHooks = new ArrayList<>();
 
 
     /**
@@ -403,5 +410,13 @@ public class ConfigSettings implements ConfigObject {
      */
     public void setIncludeShulkersInChest(boolean includeShulkersInChest) {
         this.includeShulkersInChest = includeShulkersInChest;
+    }
+
+    public List<String> getDisabledPluginHooks() {
+        return disabledPluginHooks;
+    }
+
+    public void setDisabledPluginHooks(List<String> disabledPluginHooks) {
+        this.disabledPluginHooks = disabledPluginHooks;
     }
 }


### PR DESCRIPTION
Lately i had some trouble because i'm using a modified version of UltimateStacker that does not have some features that this addon uses. I though that it would be useful for everyone in the same situation as me if there was a config option to disable some plugin hooks.


I also had to update the UltimateStacker dependency because this artifact was not found when i tried to compile.