### PR TITLE
Add more string replacements for /is level output

### DIFF
--- a/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
@@ -111,7 +111,11 @@ public class IslandLevelCommand extends CompositeCommand {
             }
             // Send player how many points are required to reach next island level
             if (results.getPointsToNextLevel() >= 0) {
-                user.sendMessage("island.level.required-points-to-next-level", "[points]", String.valueOf(results.getPointsToNextLevel()));
+                user.sendMessage("island.level.required-points-to-next-level",
+                        "[points]", String.valueOf(results.getPointsToNextLevel()),
+                        "[progress]", String.valueOf(this.addon.getSettings().getLevelCost()-results.getPointsToNextLevel()),
+                        "[levelcost]", String.valueOf(this.addon.getSettings().getLevelCost())
+                );
             }
             // Tell other team members
             if (results.getLevel() != oldLevel) {

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -42,7 +42,7 @@ island:
     estimated-wait: "&a Estimated wait: [number] seconds"
     in-queue: "&a You are number [number] in the queue"
     island-level-is: "&a Island level is &b[level]"
-    required-points-to-next-level: "&a [points] points required until the next level"
+    required-points-to-next-level: "&aLevel progress: &6[progress]&b/&e[levelcost]&a points"
     deaths: "&c([number] deaths)"
     cooldown: "&c You must wait &b[time] &c seconds until you can do that again"
     in-progress: "&6 Island level calculation is in progress..."


### PR DESCRIPTION
This add two additional string replacements for the `/is level` output, so you can now use:
- `[points]` - Number of points required for next level (existing, not changed).
- `[progress]` - Points you have already gained in this current level.
- `[levelcost]` - Total points required to complete this level.

The default message for the `en-US` language now looks like this, but I was unable to update other locales (since I don't know them):
```
Level progress: 5/100 points
```
This will not break any existing uses, as the `[points]` message has the same value as before.