### PR TITLE
Fix sorting by value in details panel

### DIFF
--- a/src/main/java/world/bentobox/level/config/BlockConfig.java
+++ b/src/main/java/world/bentobox/level/config/BlockConfig.java
@@ -64,7 +64,7 @@ public class BlockConfig {
                 // Validate
                 if (isMaterial(key) || isSpawner(key) || isOther(key)) {
                     // Store for lookup
-                    this.blockValues.put(key, blocks.getInt(key));
+                    this.blockValues.put(key.toLowerCase(Locale.ENGLISH), blocks.getInt(key));
                 } else {
                     addon.logError("Unknown listing in blocks section: " + key);
                 }

--- a/src/main/java/world/bentobox/level/panels/DetailsPanel.java
+++ b/src/main/java/world/bentobox/level/panels/DetailsPanel.java
@@ -1,14 +1,7 @@
 package world.bentobox.level.panels;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
@@ -263,6 +256,7 @@ public class DetailsPanel {
         }
         // Sort and filter
         Comparator<BlockRec> sorter;
+        System.out.println("activeFilter: " + activeFilter);
 
         switch (this.activeFilter) {
         case COUNT -> {
@@ -285,17 +279,26 @@ public class DetailsPanel {
                 blockLimit = Objects.requireNonNullElse(this.addon.getBlockConfig().getLimit(o2.key()), 0);
                 int o2Count = blockLimit > 0 ? Math.min(o2.value(), blockLimit) : o2.value();
 
+                System.out.println("o1.key(): " + o1.key());
+                System.out.println("o1.key() class: " + o1.key().getClass());
+                System.out.println("o2.key(): " + o2.key());
+
                 long o1Value = (long) o1Count
-                        * this.addon.getBlockConfig().getBlockValues().getOrDefault(o1.key(), 0);
+                        * this.addon.getBlockConfig().getBlockValues().getOrDefault(o1.key().toString().toLowerCase(Locale.ENGLISH), 0);
                 long o2Value = (long) o2Count
-                        * this.addon.getBlockConfig().getBlockValues().getOrDefault(o2.key(), 0);
+                        * this.addon.getBlockConfig().getBlockValues().getOrDefault(o2.key().toString().toLowerCase(Locale.ENGLISH), 0);
+
+                System.out.println("o1Value: " + o1Value);
+                System.out.println("o2Value: " + o2Value);
 
                 if (o1Value == o2Value) {
+                    System.out.println("has same value");
                     String o1Name = Utils.prettifyObject(o1.key(), this.user);
                     String o2Name = Utils.prettifyObject(o2.key(), this.user);
 
                     return String.CASE_INSENSITIVE_ORDER.compare(o1Name, o2Name);
                 } else {
+                    System.out.println("compare long");
                     return Long.compare(o2Value, o1Value);
                 }
             };

--- a/src/main/java/world/bentobox/level/panels/DetailsPanel.java
+++ b/src/main/java/world/bentobox/level/panels/DetailsPanel.java
@@ -256,7 +256,6 @@ public class DetailsPanel {
         }
         // Sort and filter
         Comparator<BlockRec> sorter;
-        System.out.println("activeFilter: " + activeFilter);
 
         switch (this.activeFilter) {
         case COUNT -> {
@@ -279,26 +278,17 @@ public class DetailsPanel {
                 blockLimit = Objects.requireNonNullElse(this.addon.getBlockConfig().getLimit(o2.key()), 0);
                 int o2Count = blockLimit > 0 ? Math.min(o2.value(), blockLimit) : o2.value();
 
-                System.out.println("o1.key(): " + o1.key());
-                System.out.println("o1.key() class: " + o1.key().getClass());
-                System.out.println("o2.key(): " + o2.key());
-
                 long o1Value = (long) o1Count
                         * this.addon.getBlockConfig().getBlockValues().getOrDefault(o1.key().toString().toLowerCase(Locale.ENGLISH), 0);
                 long o2Value = (long) o2Count
                         * this.addon.getBlockConfig().getBlockValues().getOrDefault(o2.key().toString().toLowerCase(Locale.ENGLISH), 0);
 
-                System.out.println("o1Value: " + o1Value);
-                System.out.println("o2Value: " + o2Value);
-
                 if (o1Value == o2Value) {
-                    System.out.println("has same value");
                     String o1Name = Utils.prettifyObject(o1.key(), this.user);
                     String o2Name = Utils.prettifyObject(o2.key(), this.user);
 
                     return String.CASE_INSENSITIVE_ORDER.compare(o1Name, o2Name);
                 } else {
-                    System.out.println("compare long");
                     return Long.compare(o2Value, o1Value);
                 }
             };


### PR DESCRIPTION
Hello, one of my players informed me that the Details panel wasn't sorting anything when selecting the "value" sort.

It seems that this issue is because : 
- in the BlockConfig, now, most of my blocks are lowercase and are added this way in the map "blockValues".
- in DetailsPanel, when sorting by value, you were getting in the map with Material (o1.key() and o2.key() are Material) instead of a String.

As a result, I : 
- ensured that the blocks added to the blockValues map are lowercase (because some in my config are also uppercase)
- converted the Material into a String and forced it to be lowercase because Material.toString() outputs an uppercase String.


Feel free to modify my PR as you like :) 