### PR TITLE
Add Oraxen furniture mechanic support for island levelling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Level** is a BentoBox add-on for Minecraft that calculates island levels based on block types and counts, maintains top-ten leaderboards, and provides competitive metrics for players on game modes like BSkyBlock and AcidIsland.
+
+## Build & Test Commands
+
+```bash
+# Build
+mvn clean package
+
+# Run all tests
+mvn test
+
+# Run a single test class
+mvn test -Dtest=LevelTest
+
+# Run a specific test method
+mvn test -Dtest=LevelTest#testMethodName
+
+# Full build with coverage
+mvn verify
+```
+
+Java 21 is required. The build produces a shaded JAR (includes PanelUtils).
+
+## Architecture
+
+### Entry Points
+- `LevelPladdon` — Bukkit plugin entry point; instantiates `Level` via the `Pladdon` interface
+- `Level` — main addon class; loads config, registers commands/listeners/placeholders, and hooks into optional third-party plugins
+
+### Lifecycle
+`onLoad()` → `onEnable()` → `allLoaded()`
+
+`allLoaded()` is where integrations with other BentoBox add-ons (Warps, Visit) are established, since those may not be loaded yet during `onEnable()`.
+
+### Key Classes
+
+| Class | Role |
+|---|---|
+| `LevelsManager` | Central manager: island level cache, top-ten lists, database reads/writes |
+| `Pipeliner` | Async queue; limits concurrent island calculations (configurable) |
+| `IslandLevelCalculator` | Core chunk-scanning algorithm; supports multiple block stacker plugins |
+| `Results` | Data object returned by a completed calculation |
+| `ConfigSettings` | Main config bound to `config.yml` via BentoBox's `@ConfigEntry` annotations |
+| `BlockConfig` | Block point-value mappings from `blockconfig.yml` |
+| `PlaceholderManager` | Registers PlaceholderAPI placeholders |
+
+### Package Layout
+```
+world/bentobox/level/
+├── calculators/     # IslandLevelCalculator, Pipeliner, Results, EquationEvaluator
+├── commands/        # Player and admin sub-commands
+├── config/          # ConfigSettings, BlockConfig
+├── events/          # IslandPreLevelEvent, IslandLevelCalculatedEvent
+├── listeners/       # Island activity, join/leave, migration listeners
+├── objects/         # IslandLevels, TopTenData (database-persisted objects)
+├── panels/          # GUI panels (top-ten, details, block values)
+├── requests/        # API request handlers for inter-addon queries
+└── util/            # Utils, ConversationUtils, CachedData
+```
+
+### Island Level Calculation Flow
+1. A calculation request enters `Pipeliner` (async queue, default concurrency = 1)
+2. `IslandLevelCalculator` scans island chunks using chunk snapshots (non-blocking)
+3. Block counts are looked up against `BlockConfig` point values
+4. An equation (configurable formula) converts total points → island level
+5. Results are stored via `LevelsManager` and fired as `IslandLevelCalculatedEvent`
+
+### Optional Plugin Integrations
+Level hooks into these plugins when present: WildStacker, RoseStacker, UltimateStacker (block counts), AdvancedChests, ItemsAdder, Oraxen (custom blocks), and the BentoBox Warps/Visit add-ons.
+
+## Testing
+
+Tests live in `src/test/java/world/bentobox/level/`. The framework is JUnit 5 + Mockito 5 + MockBukkit. `CommonTestSetup` is a shared base class that sets up the MockBukkit server and BentoBox mocks — extend it for new test classes.
+
+JaCoCo coverage reports are generated during `mvn verify`.
+
+## Configuration Resources
+
+| File | Location in JAR | Purpose |
+|---|---|---|
+| `config.yml` | `src/main/resources/` | Main settings (level cost formula, world inclusion, etc.) |
+| `blockconfig.yml` | `src/main/resources/` | Points per block type |
+| `locales/` | `src/main/resources/locales/` | Translation strings |
+| `panels/` | `src/main/resources/panels/` | GUI layout definitions |
+
+## Code Conventions
+
+- Null safety via Eclipse JDT annotations (`@NonNull`, `@Nullable`) — honour these on public APIs
+- BentoBox framework patterns: `CompositeCommand` for commands, `@ConfigEntry`/`@ConfigComment` for config, `@StoreAt` for database objects
+- Pre- and post-events (`IslandPreLevelEvent`, `IslandLevelCalculatedEvent`) follow BentoBox's cancellable event pattern — fire both when adding new calculation triggers

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <mockito.version>5.11.0</mockito.version>
         <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
-        <paper.version>1.21.10-R0.1-SNAPSHOT</paper.version>
+        <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
         <bentobox.version>3.10.2</bentobox.version>
         <!-- Warps addon version -->
         <warps.version>1.12.0</warps.version>

--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -31,9 +31,12 @@ import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Slab;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
+
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 
 import com.bgsoftware.wildstacker.api.WildStackerAPI;
 import com.bgsoftware.wildstacker.api.objects.StackedBarrel;
@@ -73,6 +76,7 @@ public class IslandLevelCalculator {
     private final int seaHeight;
     private final List<Location> stackedBlocks = new ArrayList<>();
     private final Set<Chunk> chestBlocks = new HashSet<>();
+    private final Set<Chunk> furnitureChunks = new HashSet<>();
     private final Map<Location, Boolean> spawners = new HashMap<>();
 
     /**
@@ -473,6 +477,10 @@ public class IslandLevelCalculator {
     }
 
     private void scanAsync(ChunkPair cp) {
+        // Track chunks for Oraxen furniture entity scanning (done on main thread later)
+        if (BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
+            furnitureChunks.add(cp.chunk);
+        }
         // Get the chunk coordinates and island boundaries once per chunk scan
         int chunkX = cp.chunk.getX() << 4;
         int chunkZ = cp.chunk.getZ() << 4;
@@ -741,6 +749,7 @@ public class IslandLevelCalculator {
                 // Chunk finished
                 // This was the last chunk. Handle stacked blocks, spawners, chests and exit
                 handleStackedBlocks().thenCompose(v -> handleSpawners()).thenCompose(v -> handleChests())
+                .thenCompose(v -> handleOraxenFurniture())
                 .thenRun(() -> {
                     this.tidyUp();
                     this.getR().complete(getResults());
@@ -779,6 +788,50 @@ public class IslandLevelCalculator {
             futures.add(future);
         }
         // Return a CompletableFuture that completes when all futures are done
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Scans entities in each island chunk for Oraxen furniture and counts them toward the island level.
+     * Furniture is entity-based in Oraxen (item displays / armor stands), so it is invisible to the
+     * normal block scanner. Only the base entity of each furniture piece is counted to avoid
+     * double-counting multi-entity furniture.
+     *
+     * @return a CompletableFuture that completes when all chunks have been checked
+     */
+    private CompletableFuture<Void> handleOraxenFurniture() {
+        if (!BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent() || furnitureChunks.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        int minX = island.getMinProtectedX();
+        int maxX = island.getMaxProtectedX();
+        int minZ = island.getMinProtectedZ();
+        int maxZ = island.getMaxProtectedZ();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (Chunk chunk : furnitureChunks) {
+            CompletableFuture<Void> future = Util.getChunkAtAsync(chunk.getWorld(), chunk.getX(), chunk.getZ())
+                    .thenAccept(c -> {
+                        for (Entity entity : c.getEntities()) {
+                            // Only count the root/base entity of each furniture piece
+                            if (!OraxenHook.isBaseEntity(entity)) {
+                                continue;
+                            }
+                            Location loc = entity.getLocation();
+                            // Confirm entity is within the island's protected bounds
+                            if (loc.getBlockX() < minX || loc.getBlockX() >= maxX
+                                    || loc.getBlockZ() < minZ || loc.getBlockZ() >= maxZ) {
+                                continue;
+                            }
+                            FurnitureMechanic mechanic = OraxenHook.getFurnitureMechanic(entity);
+                            if (mechanic == null) {
+                                continue;
+                            }
+                            boolean belowSeaLevel = seaHeight > 0 && loc.getBlockY() <= seaHeight;
+                            checkBlock("oraxen:" + mechanic.getItemID(), belowSeaLevel);
+                        }
+                    });
+            futures.add(future);
+        }
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
 


### PR DESCRIPTION
## Summary

Relates to #390

- Oraxen furniture is entity-based (item displays / armor stands) rather than block-based, so it was completely invisible to the existing chunk block scanner.
- After the block scan completes, a new `handleOraxenFurniture()` step iterates the entities in every island chunk, identifies Oraxen furniture **base entities** within the island's protected bounds, and counts each one using the same `"oraxen:<id>"` namespaced key already used for noteblock/stringblock mechanics.
- Only the base entity of each furniture piece is counted (via `OraxenHook.isBaseEntity()`) to prevent double-counting multi-entity furniture.
- When Oraxen is not present the new step is a no-op.

## Configuration

Furniture values are configured in `blockconfig.yml` exactly like other Oraxen items:

```yaml
blocks:
  oraxen:my_chair: 5
  oraxen:my_table: 3
```

## Test plan

- [ ] Place Oraxen furniture (furniture mechanic) on an island and run `/is level` — furniture should contribute to the level.
- [ ] Verify noteblock / stringblock mechanics still work as before.
- [ ] Verify that when Oraxen is not installed the calculation completes without errors.
- [ ] Verify furniture outside the island's protected bounds is not counted.
