### PR TITLE
Add Nexo custom block and furniture support for island levelling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
               <name>Oraxen Repository</name>
               <url>https://repo.oraxen.com/releases</url>
         </repository>
+        <!-- Nexo repo -->
+        <repository>
+            <id>nexo</id>
+            <name>Nexo Repository</name>
+            <url>https://repo.nexomc.com/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -275,6 +281,19 @@
             <groupId>dev.lone</groupId>
             <artifactId>api-itemsadder</artifactId>
             <version>4.0.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Nexo -->
+        <dependency>
+            <groupId>com.nexomc</groupId>
+            <artifactId>nexo</artifactId>
+            <version>1.19.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>dev.triumphteam</groupId>
+                    <artifactId>triumph-gui</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
         <!-- Oraxen -->

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -488,4 +488,12 @@ public class Level extends Addon {
         return !getSettings().isDisableItemsAdder() && getPlugin().getHooks().getHook("ItemsAdder").isPresent();
     }
 
+    /**
+     * @return true if the Nexo plugin is enabled and not disabled in config
+     */
+    public boolean isNexo() {
+        return !getSettings().getDisabledPluginHooks().contains("Nexo")
+                && Bukkit.getPluginManager().isPluginEnabled("Nexo");
+    }
+
 }

--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -43,6 +43,10 @@ import com.bgsoftware.wildstacker.api.objects.StackedBarrel;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import com.google.common.collect.Multisets;
+import com.nexomc.nexo.api.NexoBlocks;
+import com.nexomc.nexo.api.NexoFurniture;
+import com.nexomc.nexo.api.NexoItems;
+import com.nexomc.nexo.mechanics.custom_block.CustomBlockMechanic;
 
 import dev.rosewood.rosestacker.api.RoseStackerAPI;
 import us.lynuxcraft.deadsilenceiv.advancedchests.AdvancedChestsAPI;
@@ -426,7 +430,19 @@ public class IslandLevelCalculator {
             }
             return;
         }
-        
+        // Check Nexo
+        if (addon.isNexo() && NexoItems.exists(i)) {
+            String id = NexoItems.idFromItem(i);
+            if (id == null) {
+                return;
+            }
+            id = "nexo:" + id;
+            for (int c = 0; c < i.getAmount(); c++) {
+                checkBlock(id, false);
+            }
+            return;
+        }
+
         if (i == null || !i.getType().isBlock())
             return;
 
@@ -477,8 +493,8 @@ public class IslandLevelCalculator {
     }
 
     private void scanAsync(ChunkPair cp) {
-        // Track chunks for Oraxen furniture entity scanning (done on main thread later)
-        if (BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
+// Track chunks for furniture entity scanning (Oraxen and Nexo are entity-based)
+        if (BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent() || addon.isNexo()) {
             furnitureChunks.add(cp.chunk);
         }
         // Get the chunk coordinates and island boundaries once per chunk scan
@@ -526,10 +542,11 @@ public class IslandLevelCalculator {
         // Create a Location object only when needed for more complex checks.
         Location loc = null;
 
-        // === Custom Block Hooks (ItemsAdder, Oraxen) ===
+        // === Custom Block Hooks (ItemsAdder, Oraxen, Nexo) ===
         // These hooks can define custom blocks that override vanilla behavior.
         // They must be checked first.
-        if (addon.isItemsAdder() || BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
+        if (addon.isItemsAdder() || BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()
+                || addon.isNexo()) {
             loc = new Location(cp.world, globalX, y, globalZ);
             String customBlockId = null;
             if (addon.isItemsAdder()) {
@@ -539,6 +556,12 @@ public class IslandLevelCalculator {
                 String oraxenId = OraxenHook.getOraxenBlockID(loc);
                 if (oraxenId != null) {
                     customBlockId = "oraxen:" + oraxenId; // Make a namespaced ID
+                }
+            }
+            if (customBlockId == null && addon.isNexo()) {
+                CustomBlockMechanic nexoMechanic = NexoBlocks.customBlockMechanic(loc);
+                if (nexoMechanic != null) {
+                    customBlockId = "nexo:" + nexoMechanic.getItemID();
                 }
             }
 
@@ -750,6 +773,7 @@ public class IslandLevelCalculator {
                 // This was the last chunk. Handle stacked blocks, spawners, chests and exit
                 handleStackedBlocks().thenCompose(v -> handleSpawners()).thenCompose(v -> handleChests())
                 .thenCompose(v -> handleOraxenFurniture())
+                .thenCompose(v -> handleNexoFurniture())
                 .thenRun(() -> {
                     this.tidyUp();
                     this.getR().complete(getResults());
@@ -822,12 +846,53 @@ public class IslandLevelCalculator {
                                     || loc.getBlockZ() < minZ || loc.getBlockZ() >= maxZ) {
                                 continue;
                             }
-                            FurnitureMechanic mechanic = OraxenHook.getFurnitureMechanic(entity);
+                            var mechanic = OraxenHook.getFurnitureMechanic(entity);
                             if (mechanic == null) {
                                 continue;
                             }
                             boolean belowSeaLevel = seaHeight > 0 && loc.getBlockY() <= seaHeight;
                             checkBlock("oraxen:" + mechanic.getItemID(), belowSeaLevel);
+                        }
+                    });
+            futures.add(future);
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Scans entities in each island chunk for Nexo furniture and counts them toward the island level.
+     * Nexo furniture is entity-based (ItemDisplay entities), so it is invisible to the normal block
+     * scanner. Only entities for which a FurnitureMechanic can be resolved are counted, which
+     * naturally filters to base furniture entities.
+     *
+     * @return a CompletableFuture that completes when all chunks have been checked
+     */
+    private CompletableFuture<Void> handleNexoFurniture() {
+        if (!addon.isNexo() || furnitureChunks.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        int minX = island.getMinProtectedX();
+        int maxX = island.getMaxProtectedX();
+        int minZ = island.getMinProtectedZ();
+        int maxZ = island.getMaxProtectedZ();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (Chunk chunk : furnitureChunks) {
+            CompletableFuture<Void> future = Util.getChunkAtAsync(chunk.getWorld(), chunk.getX(), chunk.getZ())
+                    .thenAccept(c -> {
+                        for (Entity entity : c.getEntities()) {
+                            Location loc = entity.getLocation();
+                            // Confirm entity is within the island's protected bounds
+                            if (loc.getBlockX() < minX || loc.getBlockX() >= maxX
+                                    || loc.getBlockZ() < minZ || loc.getBlockZ() >= maxZ) {
+                                continue;
+                            }
+                            // getFurnitureMechanic returns non-null only for furniture base entities
+                            var mechanic = NexoFurniture.furnitureMechanic(entity);
+                            if (mechanic == null) {
+                                continue;
+                            }
+                            boolean belowSeaLevel = seaHeight > 0 && loc.getBlockY() <= seaHeight;
+                            checkBlock("nexo:" + mechanic.getItemID(), belowSeaLevel);
                         }
                     });
             futures.add(future);

--- a/src/main/java/world/bentobox/level/config/BlockConfig.java
+++ b/src/main/java/world/bentobox/level/config/BlockConfig.java
@@ -19,6 +19,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.EntityType;
 
+import com.nexomc.nexo.api.NexoItems;
+
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
 import world.bentobox.bentobox.hooks.OraxenHook;
@@ -104,6 +106,9 @@ public class BlockConfig {
         // Maybe a custom name space
         if (key.startsWith("oraxen:") && BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
             return OraxenHook.exists(key.substring(7));
+        }
+        if (key.startsWith("nexo:") && addon.isNexo()) {
+            return NexoItems.exists(key.substring(5));
         }
         // Check ItemsAdder
         return addon.isItemsAdder() && ItemsAdderHook.isInRegistry(key);

--- a/src/main/java/world/bentobox/level/util/Utils.java
+++ b/src/main/java/world/bentobox/level/util/Utils.java
@@ -161,6 +161,8 @@ public class Utils
                 // Remove prefix
                 if (key.startsWith("oraxen:")) {
                     key = key.substring(7);
+                } else if (key.startsWith("nexo:")) {
+                    key = key.substring(5);
                 }
             }
 


### PR DESCRIPTION
## Summary

Closes #389

Nexo is the successor to Oraxen and ships its own API (`com.nexomc:nexo`). This PR adds full support for all Nexo custom-block mechanics and furniture so they contribute to island level calculations.

### Custom blocks (noteblock / stringblock / chorusblock mechanics)

- `NexoBlocks.customBlockMechanic(Location)` is called in `processBlock()` alongside the existing ItemsAdder and Oraxen checks. If a Nexo custom block is found at a location it is counted as `"nexo:<itemId>"` and the method returns early (no double-counting with the vanilla block beneath).
- `NexoItems.idFromItem(ItemStack)` is checked in `countItemStack()` so Nexo items inside containers are counted when chest-scanning is enabled.

### Furniture mechanic

- Nexo furniture uses `ItemDisplay` entities rather than blocks, so it is invisible to the chunk block scanner.
- After the block scan, a new `handleNexoFurniture()` step iterates entities in every island chunk. `NexoFurniture.furnitureMechanic(entity)` returning non-null identifies the furniture's base entity; each such entity within the island's protected bounds is counted as `"nexo:<itemId>"`.

### Other changes

- **`pom.xml`** – Nexo repository and `provided`-scoped dependency added (with `triumph-gui` excluded to avoid a transitive resolution failure).
- **`Level.isNexo()`** – convenience helper that checks the plugin is enabled and not in the disabled-plugin-hooks list.
- **`BlockConfig.isOther()`** – validates `nexo:` prefixed keys via `NexoItems.exists()`.
- **`Utils.prettifyObject()`** – strips the `nexo:` prefix before looking up display names, mirroring the existing `oraxen:` handling.

## Configuration

Values are set in `blockconfig.yml` using the Nexo item ID, exactly like Oraxen:

```yaml
blocks:
  nexo:my_chair: 5
  nexo:my_table: 3
  nexo:my_noteblock_block: 10
```

To disable Nexo integration entirely, add `Nexo` to `disabled-plugin-hooks` in `config.yml`.

## Test plan

- [ ] Place Nexo custom blocks (noteblock / stringblock / chorusblock mechanics) on an island and run `/is level` — they should contribute to the level.
- [ ] Place Nexo furniture on an island and run `/is level` — furniture should contribute to the level.
- [ ] Put Nexo items inside a chest and verify they are counted when `include-chests: true`.
- [ ] Verify Oraxen and ItemsAdder blocks still work as before (priority order is unchanged).
- [ ] Verify that when Nexo is not installed the calculation completes without errors.
- [ ] Verify blocks / furniture outside the island's protected bounds are not counted.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)