### PR TITLE
Fix custom block count/value/limit placeholders for Oraxen, Nexo, ItemsAdder #391

### DIFF
--- a/src/main/java/world/bentobox/level/PlaceholderManager.java
+++ b/src/main/java/world/bentobox/level/PlaceholderManager.java
@@ -23,11 +23,16 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.nexomc.nexo.api.NexoBlocks;
+import com.nexomc.nexo.api.NexoItems;
+import com.nexomc.nexo.mechanics.custom_block.CustomBlockMechanic;
+
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
+import world.bentobox.bentobox.hooks.OraxenHook;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.level.objects.IslandLevels;
@@ -394,6 +399,30 @@ public class PlaceholderManager {
              return Material.SPAWNER; // Return generic spawner material if state invalid
         }
 
+        // Check Oraxen custom blocks (noteblock/stringblock/chorusblock mechanics)
+        if (BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
+            String oraxenId = OraxenHook.getOraxenBlockID(block.getLocation());
+            if (oraxenId != null) {
+                return "oraxen:" + oraxenId;
+            }
+        }
+
+        // Check Nexo custom blocks
+        if (addon.isNexo()) {
+            CustomBlockMechanic nexoMechanic = NexoBlocks.customBlockMechanic(block.getLocation());
+            if (nexoMechanic != null) {
+                return "nexo:" + nexoMechanic.getItemID();
+            }
+        }
+
+        // Check ItemsAdder custom blocks
+        if (addon.isItemsAdder()) {
+            String iaId = ItemsAdderHook.getInCustomRegion(block.getLocation());
+            if (iaId != null) {
+                return iaId;
+            }
+        }
+
         // Fallback to the Material for regular blocks
         return type;
     }
@@ -474,15 +503,31 @@ public class PlaceholderManager {
         } // End of Spawner handling
 
         // 2. Handle potential custom items (e.g., ItemsAdder)
-         if (addon.isItemsAdder()) {
-             Optional<String> customId = ItemsAdderHook.getNamespacedId(itemStack); 
-             if (customId.isPresent()) {
-                 return customId.get(); // Return the String ID from ItemsAdder
-             }
-         }
+        if (addon.isItemsAdder()) {
+            Optional<String> customId = ItemsAdderHook.getNamespacedId(itemStack);
+            if (customId.isPresent()) {
+                return customId.get(); // Return the String ID from ItemsAdder
+            }
+        }
 
-        // 3. Fallback to Material for regular items that represent blocks
-        return type.isBlock() ? type : null; 
+        // 3. Handle Oraxen custom items
+        if (BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()) {
+            Optional<String> oraxenId = OraxenHook.getNamespacedId(itemStack);
+            if (oraxenId.isPresent()) {
+                return "oraxen:" + oraxenId.get();
+            }
+        }
+
+        // 4. Handle Nexo custom items
+        if (addon.isNexo()) {
+            String nexoId = NexoItems.idFromItem(itemStack);
+            if (nexoId != null) {
+                return "nexo:" + nexoId;
+            }
+        }
+
+        // 5. Fallback to Material for regular items that represent blocks
+        return type.isBlock() ? type : null;
     }
 
     /**
@@ -538,16 +583,14 @@ public class PlaceholderManager {
             return material;
         }
 
-        // Assume it's a custom String key (e.g., ItemsAdder) if not resolved yet
-        if (addon.isItemsAdder() && ItemsAdderHook.isInRegistry(configKey)) { // Use original case key for lookup?
-            return configKey; 
-        }
-
         // Final check: maybe it's the generic "spawner" key from config?
-        if(lowerCaseKey.equals("spawner")) {
+        if (lowerCaseKey.equals("spawner")) {
             return Material.SPAWNER;
         }
-        return null;
+
+        // Return the key as-is for custom blocks (ItemsAdder, Oraxen, Nexo).
+        // These are stored as String keys in mdCount/uwCount.
+        return configKey;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes placeholder support for custom blocks (Oraxen, Nexo, ItemsAdder) in `PlaceholderManager`.

- **`getObjectFromConfigKey`**: Previously only returned a custom block's string key when ItemsAdder confirmed it was in its registry — Oraxen and Nexo keys always returned `null`, making `_island_count_<block>` always "0". Fixed by returning `configKey` as-is for anything that isn't a vanilla `Material` or `EntityType` spawner, since custom block strings are stored directly as `String` keys in `mdCount`/`uwCount`.
- **`getItemIdentifier`**: Added Oraxen (`OraxenHook.getNamespacedId`) and Nexo (`NexoItems.idFromItem`) lookups so `_island_count_mainhand` correctly identifies custom items held in hand.
- **`getBlockIdentifier`**: Added Oraxen (`OraxenHook.getOraxenBlockID`), Nexo (`NexoBlocks.customBlockMechanic`), and ItemsAdder (`ItemsAdderHook.getInCustomRegion`) lookups so `_island_count_looking` correctly identifies custom blocks being looked at.

## Test plan

- [x] All 22 existing tests pass
- [ ] Place an Oraxen/Nexo/ItemsAdder custom block on an island, run level calc, confirm `_island_count_<block>` placeholder returns the correct count
- [ ] Hold an Oraxen/Nexo/ItemsAdder custom item, confirm `_island_count_mainhand` returns the correct count
- [ ] Look at an Oraxen/Nexo/ItemsAdder custom block, confirm `_island_count_looking` returns the correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)