### PR TITLE
Require Member rank minimum on block donation flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
-        <bentobox.version>3.14.0</bentobox.version>
+        <bentobox.version>3.14.1-SNAPSHOT</bentobox.version>
         <!-- Warps addon version -->
         <warps.version>1.12.0</warps.version>
         <!-- Visit addon version -->

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -60,6 +60,7 @@ public class Level extends Addon {
     public static final Flag BLOCK_DONATION = new Flag.Builder("ISLAND_BLOCK_DONATION", Material.HOPPER)
             .type(Flag.Type.PROTECTION)
             .defaultRank(RanksManager.OWNER_RANK)
+            .minimumRank(RanksManager.MEMBER_RANK)
             .mode(Flag.Mode.BASIC)
             .build();
 


### PR DESCRIPTION
## Summary
- Bumps BentoBox dependency to `3.14.1-SNAPSHOT` to pick up the new `Flag.Builder.minimumRank` API
- Sets `BLOCK_DONATION` to require a minimum selectable rank of `MEMBER`, so the flag UI can never assign donation rights to VISITOR/COOP/TRUSTED

## Test plan
- [ ] `mvn clean package` succeeds against the new BentoBox snapshot
- [ ] In-game: open the protection flag panel for an island, confirm the donation flag's cycle skips ranks below MEMBER

🤖 Generated with [Claude Code](https://claude.com/claude-code)