### PR TITLE
feat: make 'hand' keyword localizable; sync locale files

### DIFF
--- a/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
@@ -60,8 +60,8 @@ public class IslandDonateCommand extends ConfirmableCommand {
             return false;
         }
 
-        // Handle "hand" subcommand
-        if (!args.isEmpty() && "hand".equalsIgnoreCase(args.get(0))) {
+        // Handle "hand" subcommand (accepts English "hand" or the localized keyword)
+        if (!args.isEmpty() && isHandKeyword(user, args.get(0))) {
             return handleHandDonation(user, island, args);
         }
 
@@ -145,15 +145,21 @@ public class IslandDonateCommand extends ConfirmableCommand {
     @Override
     public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
         String lastArg = !args.isEmpty() ? args.get(args.size() - 1) : "";
+        String handKeyword = user.getTranslation("island.donate.hand.keyword");
         if (args.size() <= 1) {
-            return Optional.of(Util.tabLimit(List.of("hand"), lastArg));
+            return Optional.of(Util.tabLimit(List.of(handKeyword), lastArg));
         }
-        if (args.size() == 2 && "hand".equalsIgnoreCase(args.get(0)) && user.isPlayer()) {
+        if (args.size() == 2 && isHandKeyword(user, args.get(0)) && user.isPlayer()) {
             int held = user.getPlayer().getInventory().getItemInMainHand().getAmount();
             if (held > 0) {
                 return Optional.of(Util.tabLimit(List.of(String.valueOf(held)), lastArg));
             }
         }
         return Optional.of(List.of());
+    }
+
+    private boolean isHandKeyword(User user, String arg) {
+        String localized = user.getTranslation("island.donate.hand.keyword");
+        return "hand".equalsIgnoreCase(arg) || localized.equalsIgnoreCase(arg);
     }
 }

--- a/src/main/java/world/bentobox/level/commands/IslandValueCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandValueCommand.java
@@ -60,7 +60,8 @@ public class IslandValueCommand extends CompositeCommand
         }
 
         String arg = args.get(0);
-        if ("HAND".equalsIgnoreCase(arg)) {
+        String handKeyword = user.getTranslation("island.donate.hand.keyword");
+        if ("HAND".equalsIgnoreCase(arg) || handKeyword.equalsIgnoreCase(arg)) {
             executeHandCommand(user);
             return true;
         }
@@ -158,7 +159,7 @@ public class IslandValueCommand extends CompositeCommand
         List<String> options = new ArrayList<>(
                 Arrays.stream(Material.values()).filter(Material::isBlock).map(Material::name).map(String::toLowerCase).toList());
 
-        options.add("HAND");
+        options.add(user.getTranslation("island.donate.hand.keyword"));
 
         return Optional.of(Util.tabLimit(options, lastArg));
     }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -53,6 +53,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Darovat lze pouze bloky s nakonfigurovanou hodnotou úrovně."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -62,6 +63,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "ruka"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Es können nur Blöcke mit einem konfigurierten Levelwert gespendet werden."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "hand"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -68,6 +68,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "hand"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -51,6 +51,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Solo se pueden donar bloques con un valor de nivel configurado."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -60,6 +61,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "mano"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -53,6 +53,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Seuls les blocs avec une valeur de niveau configurée peuvent être donnés."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -62,6 +63,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "main"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Csak konfigurált szintértékkel rendelkező blokkok adományozhatók."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "kez"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -51,6 +51,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Hanya blok dengan nilai level yang dikonfigurasi yang dapat didonasikan."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -60,6 +61,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "tangan"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>설정된 레벨 값이 있는 블록만 기부할 수 있습니다."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "hand"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Var ziedot tikai blokus ar konfigurētu līmeņa vērtību."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "roka"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -51,6 +51,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Alleen blokken met een geconfigureerde niveauwaarde kunnen worden gedoneerd."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -60,6 +61,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "hand"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -51,6 +51,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Można darować tylko bloki ze skonfigurowaną wartością poziomu."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -60,6 +61,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "reka"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Apenas blocos com um valor de nível configurado podem ser doados."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "mao"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -54,6 +54,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Можно жертвовать только блоки с настроенным значением уровня."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -63,6 +64,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "рука"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -58,6 +58,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Yalnızca yapılandırılmış seviye değerine sahip bloklar bağışlanabilir."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -67,6 +68,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "el"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -45,24 +45,26 @@ island:
     in-progress: "<gold> Розрахунок рівня острова триває..."
     time-out: "<red> Розрахунок рівня тривав занадто довго. Будь-ласка спробуйте пізніше."
   donate:
-    parameters: "[hand [amount]]"
-    description: "donate blocks to permanently raise island level"
-    must-be-on-island: "<red>You must be on your island to donate blocks."
-    no-permission: "<red>You do not have permission to donate blocks on this island."
-    no-value: "<red>That block has no level value."
-    invalid-amount: "<red>Invalid amount. Use a positive number."
-    empty: "<red>There are no valid blocks to donate."
-    cancelled: "<yellow>Donation cancelled. Items returned."
-    success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
-    confirm: "<red><bold>Confirm - Items will be DESTROYED!"
-    cancel: "<green><bold>Cancel - Return Items"
-    gui-title: "<black><bold>Donate Blocks"
-    gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
-    preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
+    parameters: "[рука [кількість]]"
+    description: "пожертвувати блоки для постійного підвищення рівня острова"
+    must-be-on-island: "<red>Щоб пожертвувати блоки, ви повинні бути на своєму острові."
+    no-permission: "<red>У вас немає дозволу жертвувати блоки на цьому острові."
+    no-value: "<red>Цей блок не має значення рівня."
+    invalid-amount: "<red>Недійсна кількість. Використовуйте позитивне число."
+    invalid-item: "<red>Можна жертвувати лише блоки з налаштованим значенням рівня."
+    empty: "<red>Немає дійсних блоків для пожертвування."
+    cancelled: "<yellow>Пожертвування скасовано. Предмети повернуто."
+    success: "<green>Пожертвовано [number] блоків за <aqua>[points]<green> очок! Ці очки є постійними."
+    confirm: "<red><bold>Підтвердити — Предмети будуть ЗНИЩЕНІ!"
+    cancel: "<green><bold>Скасувати — Повернути предмети"
+    gui-title: "<black><bold>Пожертвувати блоки"
+    gui-info: "<gold>Пожертвуйте блоки своєму острову|<gray>Пожертвовано: <gold>[points]<gray> очок|<red>Увага: пожертвувані предмети|<red>знищуються і не можуть бути повернуті!"
+    preview: "<yellow>Очок буде додано: <gold>[points]|<red>Ці предмети будуть знищені!"
     hand:
-      success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
-      not-block: "<red>You must be holding a placeable block to donate."
-      confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+      keyword: "рука"
+      success: "<green>Пожертвовано [number] x [material] за <aqua>[points]<green> постійних очок!"
+      not-block: "<red>Ви повинні тримати блок, який можна розмістити."
+      confirm-prompt: "<red>Буде ЗНИЩЕНО <gold>[number] x [material]<red> за <aqua>[points]<red> постійних очок."
   top:
     description: показати першу десятку
     gui-title: "& Десятка Кращих"
@@ -92,9 +94,8 @@ protection:
 level:
   commands:
     value:
-      parameters: "[hand|<material>]"
-      description: показує значення блоків. Додайте 'hand' в кінці, щоб відобразити
-        значення предмета в руках.
+      parameters: "[рука|<матеріал>]"
+      description: показує значення блоків. Додайте 'рука' в кінці, щоб відобразити значення предмета в руках.
   gui:
     titles:
       top: "<black><bold> Топ островів"

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -57,6 +57,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>Chỉ có thể quyên góp các khối có giá trị cấp độ được cấu hình."
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -66,6 +67,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "tay"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -49,6 +49,7 @@ island:
     no-permission: "<red>You do not have permission to donate blocks on this island."
     no-value: "<red>That block has no level value."
     invalid-amount: "<red>Invalid amount. Use a positive number."
+    invalid-item: "<red>只能捐赠具有配置等级值的方块。"
     empty: "<red>There are no valid blocks to donate."
     cancelled: "<yellow>Donation cancelled. Items returned."
     success: "<green>Donated [number] blocks for <aqua>[points]<green> points! These points are permanent."
@@ -58,6 +59,7 @@ island:
     gui-info: "<gold>Donate blocks to your island|<gray>Currently donated: <gold>[points]<gray> points|<red>Warning: donated items are|<red>destroyed and cannot be returned!"
     preview: "<yellow>Points to add: <gold>[points]|<red>These items will be destroyed!"
     hand:
+      keyword: "hand"
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."

--- a/src/test/java/world/bentobox/level/commands/IslandDonateCommandTest.java
+++ b/src/test/java/world/bentobox/level/commands/IslandDonateCommandTest.java
@@ -64,6 +64,7 @@ public class IslandDonateCommandTest extends CommonTestSetup {
         when(user.getTranslation(anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation(anyString(), anyString(), anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
+        when(user.getTranslation("island.donate.hand.keyword")).thenReturn("hand");
         when(user.getLocation()).thenReturn(location);
 
         when(player.getInventory()).thenReturn(inventory);

--- a/src/test/java/world/bentobox/level/commands/IslandValueCommandTest.java
+++ b/src/test/java/world/bentobox/level/commands/IslandValueCommandTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +69,7 @@ public class IslandValueCommandTest extends CommonTestSetup {
         when(user.getTranslation(anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation(anyString(), anyString(), anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
+        when(user.getTranslation("island.donate.hand.keyword")).thenReturn("hand");
         when(user.getTranslationOrNothing(anyString())).thenReturn("");
 
         when(player.getInventory()).thenReturn(inventory);
@@ -109,7 +111,7 @@ public class IslandValueCommandTest extends CommonTestSetup {
     public void testExecuteUnknownMaterial() {
         assertTrue(cmd.execute(user, "value", List.of("NOTAMATERIAL")));
         // Sends unknown-item message via Utils.sendMessage
-        verify(user).getTranslation(anyString()); // translation called for unknown item message
+        verify(user, times(2)).getTranslation(anyString()); // keyword lookup + unknown item message
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Makes the `hand` keyword in `/island donate` and `/island value` localizable via a new `island.donate.hand.keyword` locale key — English `hand` always accepted as a fallback for backward compatibility
- Syncs all 16 non-English locale files with missing keys from `en-US.yml`
- Adds the missing `island.donate.invalid-item` key to all non-English locales
- Fully translates the `island.donate.*` section in `uk.yml` (was entirely in English)
- Updates `uk.yml` donate/value command parameter display strings to use Ukrainian keyword (`рука`)

## Code changes

**`IslandDonateCommand.java`**
- `"hand".equalsIgnoreCase(args.get(0))` → `isHandKeyword(user, args.get(0))` helper that accepts both English and localized keyword
- Tab completion returns the localized keyword

**`IslandValueCommand.java`**
- Same localized keyword check for the `hand` argument

**`en-US.yml`**
- Added `island.donate.hand.keyword: "hand"`

## Test plan
- [x] `IslandDonateCommandTest` and `IslandValueCommandTest` updated and passing
- [x] `mvn test` passes (175 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)