### PR TITLE
feat: add CraftEngine custom block support for island level calculation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
-        <bentobox.version>3.14.1-SNAPSHOT</bentobox.version>
+        <bentobox.version>3.15.0-SNAPSHOT</bentobox.version>
         <!-- Warps addon version -->
         <warps.version>1.12.0</warps.version>
         <!-- Visit addon version -->

--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -515,4 +515,12 @@ public class Level extends Addon {
                 && Bukkit.getPluginManager().isPluginEnabled("Nexo");
     }
 
+    /**
+     * @return true if the CraftEngine plugin is hooked and not disabled in config
+     */
+    public boolean isCraftEngine() {
+        return !getSettings().getDisabledPluginHooks().contains("CraftEngine")
+                && getPlugin().getHooks().getHook("CraftEngine").isPresent();
+    }
+
 }

--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -54,6 +54,7 @@ import us.lynuxcraft.deadsilenceiv.advancedchests.chest.AdvancedChest;
 import us.lynuxcraft.deadsilenceiv.advancedchests.chest.gui.page.ChestPage;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.hooks.CraftEngineHook;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
 import world.bentobox.bentobox.hooks.OraxenHook;
 import world.bentobox.bentobox.util.Pair;
@@ -562,11 +563,11 @@ public class IslandLevelCalculator {
         // Create a Location object only when needed for more complex checks.
         Location loc = null;
 
-        // === Custom Block Hooks (ItemsAdder, Oraxen, Nexo) ===
+        // === Custom Block Hooks (ItemsAdder, Oraxen, Nexo, CraftEngine) ===
         // These hooks can define custom blocks that override vanilla behavior.
         // They must be checked first.
         if (addon.isItemsAdder() || BentoBox.getInstance().getHooks().getHook("Oraxen").isPresent()
-                || addon.isNexo()) {
+                || addon.isNexo() || addon.isCraftEngine()) {
             loc = new Location(cp.world, globalX, y, globalZ);
             String customBlockId = null;
             if (addon.isItemsAdder()) {
@@ -583,6 +584,9 @@ public class IslandLevelCalculator {
                 if (nexoMechanic != null) {
                     customBlockId = "nexo:" + nexoMechanic.getItemID();
                 }
+            }
+            if (customBlockId == null && addon.isCraftEngine()) {
+                customBlockId = CraftEngineHook.getBlockId(loc);
             }
 
             if (customBlockId != null) {

--- a/src/main/java/world/bentobox/level/config/BlockConfig.java
+++ b/src/main/java/world/bentobox/level/config/BlockConfig.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.EntityType;
 import com.nexomc.nexo.api.NexoItems;
 
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.hooks.CraftEngineHook;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
 import world.bentobox.bentobox.hooks.OraxenHook;
 import world.bentobox.level.Level;
@@ -111,7 +112,11 @@ public class BlockConfig {
             return NexoItems.exists(key.substring(5));
         }
         // Check ItemsAdder
-        return addon.isItemsAdder() && ItemsAdderHook.isInRegistry(key);
+        if (addon.isItemsAdder() && ItemsAdderHook.isInRegistry(key)) {
+            return true;
+        }
+        // Check CraftEngine — block IDs are already namespaced (e.g. "mynamespace:my_block")
+        return addon.isCraftEngine() && CraftEngineHook.exists(key);
     }
 
     private boolean isSpawner(String key) {


### PR DESCRIPTION
## Summary

- Adds CraftEngine block detection to `processBlock()` alongside ItemsAdder, Oraxen, and Nexo
- Adds `isCraftEngine()` to `Level.java` following the same pattern as `isItemsAdder()` / `isNexo()`
- Validates CraftEngine block IDs in `BlockConfig.isOther()` so admins can configure point values in `blockconfig.yml`
- Bumps `bentobox.version` to `3.15.0-SNAPSHOT` (requires BentoBoxWorld/BentoBox#2952)

## How it works

CraftEngine blocks are identified by their native namespaced ID (e.g. `mynamespace:my_block`). In `blockconfig.yml` admins assign values using those IDs directly:

```yaml
blocks:
  mynamespace:my_block: 50
  mynamespace:custom_ore: 3
```

CraftEngine can be excluded from level calculation by adding `CraftEngine` to `disabled-plugin-hooks` in the Level config.

## Context

Requested in issue #418. BentoBoxWorld/BentoBox#2952 adds the `CraftEngineHook` that this PR uses — no direct CraftEngine compile dependency is needed in Level.

**Depends on:** BentoBoxWorld/BentoBox#2952

## Test plan

- [ ] Island with CraftEngine blocks → blocks counted with configured point values
- [ ] `disabled-plugin-hooks: [CraftEngine]` in config → CE blocks ignored (counted as vanilla material)
- [ ] Server without CraftEngine → no errors, CE check silently skipped
- [ ] Custom CE block IDs accepted in `blockconfig.yml`; invalid IDs rejected with log warning
- [ ] Existing ItemsAdder / Oraxen / Nexo detection unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)