### PR TITLE
feat: /island donate inv — donate everything from inventory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>2.26.0</build.version>
+        <build.version>2.27.0</build.version>
         <sonar.projectKey>BentoBoxWorld_Level</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
@@ -1,10 +1,13 @@
 package world.bentobox.level.commands;
 
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.ConfirmableCommand;
@@ -17,8 +20,9 @@ import world.bentobox.level.panels.DonationPanel;
 import world.bentobox.level.util.Utils;
 
 /**
- * Command: /island donate [hand [amount]]
- * Opens a donation GUI or donates blocks from hand.
+ * Command: /island donate [hand [amount]] [inv]
+ * Opens a donation GUI, or donates blocks from the player's hand, or
+ * donates every donatable block from the player's inventory.
  *
  * @author tastybento
  */
@@ -63,6 +67,11 @@ public class IslandDonateCommand extends ConfirmableCommand {
         // Handle "hand" subcommand (accepts English "hand" or the localized keyword)
         if (!args.isEmpty() && isHandKeyword(user, args.get(0))) {
             return handleHandDonation(user, island, args);
+        }
+
+        // Handle "inv" subcommand (accepts English "inv" or the localized keyword)
+        if (!args.isEmpty() && isInvKeyword(user, args.get(0))) {
+            return handleInvDonation(user, island);
         }
 
         // No args - open GUI
@@ -142,14 +151,106 @@ public class IslandDonateCommand extends ConfirmableCommand {
                 "[points]", Utils.formatNumber(user, points));
     }
 
+    /**
+     * Handle the /island donate inv subcommand. Scans the player's inventory for
+     * blocks with a positive donation value, shows a per-material breakdown plus
+     * the total, and asks for confirmation. Items with no value or that aren't
+     * donatable blocks remain in the inventory.
+     */
+    private boolean handleInvDonation(User user, Island island) {
+        Map<Material, Integer> totals = collectDonatableTotals(user.getPlayer().getInventory());
+
+        if (totals.isEmpty()) {
+            user.sendMessage("island.donate.empty");
+            return false;
+        }
+
+        long totalPoints = 0L;
+        StringBuilder prompt = new StringBuilder(
+                user.getTranslation("island.donate.inv.confirm-header"));
+        for (Map.Entry<Material, Integer> e : totals.entrySet()) {
+            int value = addon.getBlockConfig().getValue(getWorld(), e.getKey());
+            long points = (long) value * e.getValue();
+            totalPoints += points;
+            prompt.append('\n').append(user.getTranslation("island.donate.inv.confirm-line",
+                    TextVariables.NUMBER, String.valueOf(e.getValue()),
+                    "[material]", Utils.prettifyObject(e.getKey(), user),
+                    "[points]", Utils.formatNumber(user, points)));
+        }
+        prompt.append('\n').append(user.getTranslation("island.donate.inv.confirm-total",
+                "[points]", Utils.formatNumber(user, totalPoints)));
+
+        askConfirmation(user, prompt.toString(), () -> performInvDonation(user, island));
+        return true;
+    }
+
+    private void performInvDonation(User user, Island island) {
+        PlayerInventory pInv = user.getPlayer().getInventory();
+        ItemStack[] contents = pInv.getStorageContents();
+        Map<Material, Integer> donated = new EnumMap<>(Material.class);
+        long totalPoints = 0L;
+
+        for (int i = 0; i < contents.length; i++) {
+            ItemStack item = contents[i];
+            Integer value = donationValue(item);
+            if (value == null) {
+                continue;
+            }
+            int amount = item.getAmount();
+            long points = (long) value * amount;
+            donated.merge(item.getType(), amount, Integer::sum);
+            totalPoints += points;
+            addon.getManager().donateBlocks(island, user.getUniqueId(), item.getType().name(), amount, points);
+            contents[i] = null;
+        }
+        pInv.setStorageContents(contents);
+
+        if (donated.isEmpty()) {
+            user.sendMessage("island.donate.empty");
+            return;
+        }
+        int totalBlocks = donated.values().stream().mapToInt(Integer::intValue).sum();
+        user.sendMessage("island.donate.success",
+                "[points]", Utils.formatNumber(user, totalPoints),
+                TextVariables.NUMBER, String.valueOf(totalBlocks));
+        addon.getManager().recalculateAfterDonation(island);
+    }
+
+    private Map<Material, Integer> collectDonatableTotals(PlayerInventory pInv) {
+        Map<Material, Integer> totals = new EnumMap<>(Material.class);
+        for (ItemStack item : pInv.getStorageContents()) {
+            if (donationValue(item) != null) {
+                totals.merge(item.getType(), item.getAmount(), Integer::sum);
+            }
+        }
+        return totals;
+    }
+
+    /**
+     * @return the per-block donation value if the item is a donatable block with a
+     *         positive configured value, or null otherwise
+     */
+    private Integer donationValue(ItemStack item) {
+        if (item == null || item.getType().isAir() || !item.getType().isBlock()) {
+            return null;
+        }
+        Integer value = addon.getBlockConfig().getValue(getWorld(), item.getType());
+        return (value != null && value > 0) ? value : null;
+    }
+
     @Override
     public Optional<List<String>> tabComplete(User user, String alias, List<String> args) {
+        // BentoBox includes the command label as args.get(0); the user-typed args start at index 1.
         String lastArg = !args.isEmpty() ? args.get(args.size() - 1) : "";
         String handKeyword = user.getTranslation("island.donate.hand.keyword");
-        if (args.size() <= 1) {
-            return Optional.of(Util.tabLimit(List.of(handKeyword), lastArg));
+        String invKeyword = user.getTranslation("island.donate.inv.keyword");
+
+        // First user-arg slot: suggest "hand" and "inv".
+        if (args.size() <= 2) {
+            return Optional.of(Util.tabLimit(List.of(handKeyword, invKeyword), lastArg));
         }
-        if (args.size() == 2 && isHandKeyword(user, args.get(0)) && user.isPlayer()) {
+        // Second user-arg slot after "hand": suggest the held count.
+        if (args.size() == 3 && isHandKeyword(user, args.get(1)) && user.isPlayer()) {
             int held = user.getPlayer().getInventory().getItemInMainHand().getAmount();
             if (held > 0) {
                 return Optional.of(Util.tabLimit(List.of(String.valueOf(held)), lastArg));
@@ -161,5 +262,10 @@ public class IslandDonateCommand extends ConfirmableCommand {
     private boolean isHandKeyword(User user, String arg) {
         String localized = user.getTranslation("island.donate.hand.keyword");
         return "hand".equalsIgnoreCase(arg) || localized.equalsIgnoreCase(arg);
+    }
+
+    private boolean isInvKeyword(User user, String arg) {
+        String localized = user.getTranslation("island.donate.inv.keyword");
+        return "inv".equalsIgnoreCase(arg) || localized.equalsIgnoreCase(arg);
     }
 }

--- a/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandDonateCommand.java
@@ -28,6 +28,9 @@ import world.bentobox.level.util.Utils;
  */
 public class IslandDonateCommand extends ConfirmableCommand {
 
+    private static final String MATERIAL_PLACEHOLDER = "[material]";
+    private static final String POINTS_PLACEHOLDER = "[points]";
+
     private final Level addon;
 
     public IslandDonateCommand(Level addon, CompositeCommand parent) {
@@ -120,8 +123,8 @@ public class IslandDonateCommand extends ConfirmableCommand {
 
         String prompt = user.getTranslation("island.donate.hand.confirm-prompt",
                 TextVariables.NUMBER, String.valueOf(previewAmount),
-                "[material]", Utils.prettifyObject(material, user),
-                "[points]", Utils.formatNumber(user, previewPoints));
+                MATERIAL_PLACEHOLDER, Utils.prettifyObject(material, user),
+                POINTS_PLACEHOLDER, Utils.formatNumber(user, previewPoints));
 
         askConfirmation(user, prompt, () -> performHandDonation(user, island, material, blockValue, finalRequested));
         return true;
@@ -147,8 +150,8 @@ public class IslandDonateCommand extends ConfirmableCommand {
 
         user.sendMessage("island.donate.hand.success",
                 TextVariables.NUMBER, String.valueOf(amount),
-                "[material]", Utils.prettifyObject(material, user),
-                "[points]", Utils.formatNumber(user, points));
+                MATERIAL_PLACEHOLDER, Utils.prettifyObject(material, user),
+                POINTS_PLACEHOLDER, Utils.formatNumber(user, points));
     }
 
     /**
@@ -174,11 +177,11 @@ public class IslandDonateCommand extends ConfirmableCommand {
             totalPoints += points;
             prompt.append('\n').append(user.getTranslation("island.donate.inv.confirm-line",
                     TextVariables.NUMBER, String.valueOf(e.getValue()),
-                    "[material]", Utils.prettifyObject(e.getKey(), user),
-                    "[points]", Utils.formatNumber(user, points)));
+                    MATERIAL_PLACEHOLDER, Utils.prettifyObject(e.getKey(), user),
+                    POINTS_PLACEHOLDER, Utils.formatNumber(user, points)));
         }
         prompt.append('\n').append(user.getTranslation("island.donate.inv.confirm-total",
-                "[points]", Utils.formatNumber(user, totalPoints)));
+                POINTS_PLACEHOLDER, Utils.formatNumber(user, totalPoints)));
 
         askConfirmation(user, prompt.toString(), () -> performInvDonation(user, island));
         return true;
@@ -211,7 +214,7 @@ public class IslandDonateCommand extends ConfirmableCommand {
         }
         int totalBlocks = donated.values().stream().mapToInt(Integer::intValue).sum();
         user.sendMessage("island.donate.success",
-                "[points]", Utils.formatNumber(user, totalPoints),
+                POINTS_PLACEHOLDER, Utils.formatNumber(user, totalPoints),
                 TextVariables.NUMBER, String.valueOf(totalBlocks));
         addon.getManager().recalculateAfterDonation(island);
     }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -67,6 +67,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Tyto bloky budou ZNIČENY z tvého inventáře:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> bodů"
+      confirm-total: "<red>Celkem: <aqua>[points]<red> trvalých bodů."
   detail:
     description: "zobrazit podrobnosti o blocích vašeho ostrova"
   top:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Diese Blöcke werden aus deinem Inventar ZERSTÖRT:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> Punkte"
+      confirm-total: "<red>Gesamt: <aqua>[points]<red> permanente Punkte."
   detail:
     description: "zeigt Details der Blöcke deiner Insel"
   top:

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -52,7 +52,7 @@ island:
     in-progress: "<gold>Island level calculation is in progress..."
     time-out: "<red>The level calculation took too long. Please try again later."
   donate:
-    parameters: "[hand [amount]]"
+    parameters: "[hand [amount]] [inv]"
     description: "donate blocks to permanently raise island level"
     must-be-on-island: "<red>You must be on your island to donate blocks."
     no-permission: "<red>You do not have permission to donate blocks on this island."
@@ -72,6 +72,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>About to DESTROY these blocks from your inventory:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> points"
+      confirm-total: "<red>Total: <aqua>[points]<red> permanent points."
   detail:
     description: "shows detail of your island blocks"
   top:

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -65,6 +65,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Estos bloques serán DESTRUIDOS de tu inventario:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> puntos"
+      confirm-total: "<red>Total: <aqua>[points]<red> puntos permanentes."
   detail:
     description: "muestra el detalle de los bloques de tu isla"
   top:

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -67,6 +67,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Ces blocs vont être DÉTRUITS de votre inventaire :"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> points"
+      confirm-total: "<red>Total : <aqua>[points]<red> points permanents."
   top:
     description: affiche le top 10
     gui-title: "<green>Top 10"

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Ezeket a blokkokat MEGSEMMISÍTI a leltáradból:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> pont"
+      confirm-total: "<red>Összesen: <aqua>[points]<red> állandó pont."
   detail:
     description: "megmutatja a szigeted blokkjainak részleteit"
   top:

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -65,6 +65,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Akan MENGHANCURKAN blok-blok ini dari inventaris Anda:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> poin"
+      confirm-total: "<red>Total: <aqua>[points]<red> poin permanen."
   top:
     description: menunjukkan Sepuluh Besar
     gui-title: "<green> Sepuluh Besar"

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>인벤토리에서 다음 블록을 파괴합니다:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> 점"
+      confirm-total: "<red>총: <aqua>[points]<red> 영구 점수."
   detail:
     description: "섬 블록의 세부 정보를 표시합니다"
   top:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Šie bloki tiks IZNĪCINĀTI no tavas somas:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> punkti"
+      confirm-total: "<red>Kopā: <aqua>[points]<red> pastāvīgi punkti."
   detail:
     description: "rāda tavas salas bloku detaļas"
   top:

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -65,6 +65,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Deze blokken worden VERNIETIGD uit je inventaris:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> punten"
+      confirm-total: "<red>Totaal: <aqua>[points]<red> permanente punten."
   top:
     description: Toon de Top tien
     gui-title: "<green> Top tien"

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -65,6 +65,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Te bloki zostaną ZNISZCZONE z twojego ekwipunku:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> punktów"
+      confirm-total: "<red>Łącznie: <aqua>[points]<red> punktów stałych."
   top:
     description: pokauje Top 10 wysp
     gui-title: "<green>Top 10"

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Estes blocos serão DESTRUÍDOS do seu inventário:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> pontos"
+      confirm-total: "<red>Total: <aqua>[points]<red> pontos permanentes."
   detail:
     description: "mostra os detalhes dos blocos da sua ilha"
   top:

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -68,6 +68,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Эти блоки будут УНИЧТОЖЕНЫ из вашего инвентаря:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> очков"
+      confirm-total: "<red>Всего: <aqua>[points]<red> постоянных очков."
   detail:
     description: показать информацию о блоках на вашем острове
   top:

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -72,6 +72,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Envanterinizden bu bloklar YOK EDİLECEK:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> puan"
+      confirm-total: "<red>Toplam: <aqua>[points]<red> kalıcı puan."
   detail:
     description: "adanın blok ayrıntılarını gösterir"
   top:

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -65,6 +65,11 @@ island:
       success: "<green>Пожертвовано [number] x [material] за <aqua>[points]<green> постійних очок!"
       not-block: "<red>Ви повинні тримати блок, який можна розмістити."
       confirm-prompt: "<red>Буде ЗНИЩЕНО <gold>[number] x [material]<red> за <aqua>[points]<red> постійних очок."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Ці блоки будуть ЗНИЩЕНІ з вашого інвентарю:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> очок"
+      confirm-total: "<red>Всього: <aqua>[points]<red> постійних очок."
   top:
     description: показати першу десятку
     gui-title: "& Десятка Кращих"

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -71,6 +71,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>Sắp PHÁ HỦY những khối này từ kho đồ của bạn:"
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> điểm"
+      confirm-total: "<red>Tổng: <aqua>[points]<red> điểm vĩnh viễn."
   detail:
     description: "hiển thị chi tiết các khối trên đảo của bạn"
   top:

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -63,6 +63,11 @@ island:
       success: "<green>Donated [number] x [material] for <aqua>[points]<green> permanent points!"
       not-block: "<red>You must be holding a placeable block to donate."
       confirm-prompt: "<red>About to DESTROY <gold>[number] x [material]<red> for <aqua>[points]<red> permanent points."
+    inv:
+      keyword: "inv"
+      confirm-header: "<red>即将从你的物品栏销毁以下方块："
+      confirm-line: "<gold>[number] x [material] <gray>= <aqua>[points]<gray> 点"
+      confirm-total: "<red>共计: <aqua>[points]<red> 永久点数。"
   
   top:
     description: 显示前十名

--- a/src/test/java/world/bentobox/level/commands/IslandDonateCommandTest.java
+++ b/src/test/java/world/bentobox/level/commands/IslandDonateCommandTest.java
@@ -4,14 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.bukkit.Location;
@@ -65,6 +70,10 @@ class IslandDonateCommandTest extends CommonTestSetup {
         when(user.getTranslation(anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation(anyString(), anyString(), anyString(), anyString(), anyString())).thenAnswer(i -> i.getArgument(0, String.class));
         when(user.getTranslation("island.donate.hand.keyword")).thenReturn("hand");
+        when(user.getTranslation("island.donate.inv.keyword")).thenReturn("inv");
+        when(user.getTranslationOrNothing(anyString())).thenReturn("");
+        when(user.getTranslationOrNothing(anyString(), anyString(), anyString())).thenReturn("");
+        when(user.getLocale()).thenReturn(Locale.US);
         when(user.getLocation()).thenReturn(location);
 
         when(player.getInventory()).thenReturn(inventory);
@@ -156,9 +165,87 @@ class IslandDonateCommandTest extends CommonTestSetup {
 
     @Test
     void testTabCompleteNoArgs() {
-        // When no args, should suggest "hand"
+        // When no args, should suggest "hand" and "inv"
         var result = cmd.tabComplete(user, "donate", Collections.emptyList());
         assertTrue(result.isPresent());
         assertTrue(result.get().contains("hand"));
+        assertTrue(result.get().contains("inv"));
+    }
+
+    @Test
+    void testTabCompleteFirstArgFromBentoBoxFlow() {
+        // BentoBox passes the leaf command label as args.get(0); the partial first
+        // user arg sits in args.get(1). Empty string = bare "/island donate <TAB>".
+        var result = cmd.tabComplete(user, "donate", List.of("donate", ""));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("hand"));
+        assertTrue(result.get().contains("inv"));
+    }
+
+    @Test
+    void testTabCompleteSecondArgAfterHandSuggestsHeldAmount() {
+        ItemStack stack = mock(ItemStack.class);
+        when(stack.getAmount()).thenReturn(7);
+        when(inventory.getItemInMainHand()).thenReturn(stack);
+
+        var result = cmd.tabComplete(user, "donate", List.of("donate", "hand", ""));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("7"));
+    }
+
+    @Test
+    void testTabCompleteAfterInvSuggestsNothing() {
+        var result = cmd.tabComplete(user, "donate", List.of("donate", "inv", ""));
+        assertTrue(result.isPresent());
+        assertTrue(result.get().isEmpty());
+    }
+
+    @Test
+    void testExecuteInvEmptyInventory() {
+        when(inventory.getStorageContents()).thenReturn(new ItemStack[] { null, null, null });
+
+        assertFalse(cmd.execute(user, "donate", List.of("inv")));
+        verify(user).sendMessage("island.donate.empty");
+        verify(manager, never()).donateBlocks(any(), any(UUID.class), anyString(), anyInt(), anyLong());
+    }
+
+    @Test
+    void testExecuteInvNoValuableBlocks() {
+        // Stone with no value, sword (not a block)
+        ItemStack stone = mock(ItemStack.class);
+        when(stone.getType()).thenReturn(Material.STONE);
+        when(stone.getAmount()).thenReturn(5);
+        ItemStack sword = mock(ItemStack.class);
+        when(sword.getType()).thenReturn(Material.DIAMOND_SWORD);
+        when(inventory.getStorageContents()).thenReturn(new ItemStack[] { stone, sword });
+        when(blockConfig.getValue(any(), eq(Material.STONE))).thenReturn(null);
+
+        assertFalse(cmd.execute(user, "donate", List.of("inv")));
+        verify(user).sendMessage("island.donate.empty");
+        verify(manager, never()).donateBlocks(any(), any(UUID.class), anyString(), anyInt(), anyLong());
+    }
+
+    @Test
+    void testExecuteInvShowsConfirmationPrompt() {
+        ItemStack diamond = mock(ItemStack.class);
+        when(diamond.getType()).thenReturn(Material.DIAMOND_BLOCK);
+        when(diamond.getAmount()).thenReturn(2);
+        ItemStack gold = mock(ItemStack.class);
+        when(gold.getType()).thenReturn(Material.GOLD_BLOCK);
+        when(gold.getAmount()).thenReturn(3);
+        // Non-donatable item is ignored, not destroyed
+        ItemStack sword = mock(ItemStack.class);
+        when(sword.getType()).thenReturn(Material.DIAMOND_SWORD);
+
+        when(inventory.getStorageContents())
+                .thenReturn(new ItemStack[] { diamond, sword, gold });
+        when(blockConfig.getValue(any(), eq(Material.DIAMOND_BLOCK))).thenReturn(100);
+        when(blockConfig.getValue(any(), eq(Material.GOLD_BLOCK))).thenReturn(50);
+
+        assertTrue(cmd.execute(user, "donate", List.of("inv")));
+        // The confirmation header should have been requested via getTranslation
+        verify(user).getTranslation("island.donate.inv.confirm-header");
+        // No donation yet — only confirmation requested
+        verify(manager, never()).donateBlocks(any(), any(UUID.class), anyString(), anyInt(), anyLong());
     }
 }


### PR DESCRIPTION
## Summary
- Adds confirmable `/island donate inv` subcommand: lists every donatable block in the player's inventory with per-material values and a total, then on confirm donates them all and runs a level recalc. Items with no value or non-blocks stay in the inventory.
- Adjusts help text: `parameters: "[hand [amount]] [inv]"` to show `[inv]` as an optional alternative.
- Fixes donate tab-complete — BentoBox passes the leaf command label at `args.get(0)`, so the prior `args.size() <= 1` branch never fired in real use and only auto `help` showed. Tab-complete now suggests `hand` / `inv` for the first user-arg slot and the held-item count after `hand`. Tests now exercise the realistic args shape (`["donate", ""]`).
- Bumps build version 2.26.0 → 2.27.0.

## Test plan
- [x] `mvn test` (47 tests, all green)
- [x] `mvn package` produces `Level-2.27.0-SNAPSHOT-LOCAL.jar`
- [x] In-game: `/is donate <TAB>` shows `hand`, `inv`, `help`
- [x] In-game: `/is donate inv` shows the per-material breakdown + total, then on re-issue donates and recalculates the level
- [x] In-game: items with zero/no configured value stay in the inventory after `inv` donation
- [x] In-game: `/is donate hand <TAB>` still suggests the held count

🤖 Generated with [Claude Code](https://claude.com/claude-code)