### PR TITLE
FIXED: Negative values in progression while using a non-linear function.

### DIFF
--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -751,12 +751,29 @@ public class IslandLevelCalculator {
         this.results.level.set(calculateLevel(blockAndDeathPoints));
 
         // Calculate how many points are required to get to the next level
-        long nextLevel = this.results.level.get();
+        long currentLevel = this.results.level.get();
+        long nextLevel = currentLevel;
         long blocks = blockAndDeathPoints;
-        while (nextLevel < this.results.level.get() + 1 && blocks - blockAndDeathPoints < MAX_AMOUNT) {
+        while (nextLevel < currentLevel + 1 && blocks - blockAndDeathPoints < MAX_AMOUNT) {
             nextLevel = calculateLevel(++blocks);
         }
         this.results.pointsToNextLevel.set(blocks - blockAndDeathPoints);
+
+        // Calculate how many points have been accumulated within the current level by
+        // walking back to the smallest block count that still yields the current level.
+        // For non-linear level formulas the per-level interval is not equal to the
+        // configured level cost, so we derive the actual interval here.
+        // Floor the probe at initialCount when zeroing new island levels: calculateLevel
+        // subtracts initialCount internally, so probing below it produces negative
+        // modifiedPoints which yield NaN (sqrt, log) or negative fractions that truncate
+        // to 0 — both compare >= to a level-0 island and would walk the loop to MAX_AMOUNT.
+        long minBlocks = addon.getSettings().isZeroNewIslandLevels() ? results.initialCount.get() : 0;
+        long lowerBlocks = blockAndDeathPoints;
+        while (lowerBlocks > minBlocks && blockAndDeathPoints - lowerBlocks < MAX_AMOUNT
+                && calculateLevel(lowerBlocks - 1) >= currentLevel) {
+            lowerBlocks--;
+        }
+        this.results.pointsFromCurrentLevel.set(blockAndDeathPoints - lowerBlocks);
 
         // Report
         results.report = getReport();

--- a/src/main/java/world/bentobox/level/calculators/Results.java
+++ b/src/main/java/world/bentobox/level/calculators/Results.java
@@ -48,6 +48,14 @@ public class Results {
     AtomicLong level = new AtomicLong(0);
     AtomicInteger deathHandicap = new AtomicInteger(0);
     AtomicLong pointsToNextLevel = new AtomicLong(0);
+    /**
+     * Points already accumulated within the current level (i.e. how far past the
+     * start-of-current-level threshold the island has progressed). Combined with
+     * {@link #pointsToNextLevel} this gives the actual size of the current level
+     * interval — which is what should be shown to players when the configured
+     * level formula is non-linear.
+     */
+    AtomicLong pointsFromCurrentLevel = new AtomicLong(0);
     //AtomicLong initialLevel = new AtomicLong(0);
     AtomicLong initialCount = new AtomicLong(0);
     /**
@@ -113,6 +121,21 @@ public class Results {
      */
     public void setPointsToNextLevel(long points) {
         pointsToNextLevel.set(points);
+    }
+
+    /**
+     * @return the points already accumulated within the current level
+     */
+    public long getPointsFromCurrentLevel() {
+        return pointsFromCurrentLevel.get();
+    }
+
+    /**
+     * Set the points already accumulated within the current level
+     * @param points
+     */
+    public void setPointsFromCurrentLevel(long points) {
+        pointsFromCurrentLevel.set(points);
     }
 
     /**

--- a/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandLevelCommand.java
@@ -110,12 +110,20 @@ public class IslandLevelCommand extends CompositeCommand {
             if (addon.getSettings().getDeathPenalty() != 0) {
                 user.sendMessage("island.level.deaths", "[number]", String.valueOf(results.getDeathHandicap()));
             }
-            // Send player how many points are required to reach next island level
+            // Send player how many points are required to reach next island level.
+            // Use the actual interval between the current and next level so the progress
+            // ratio is correct for non-linear level formulas (log/sqrt/etc.) — the
+            // configured level_cost only matches the interval for the default linear
+            // formula and would otherwise yield negative or misleading values.
             if (results.getPointsToNextLevel() >= 0) {
+                long interval = results.getPointsFromCurrentLevel() + results.getPointsToNextLevel();
+                if (interval <= 0) {
+                    interval = this.addon.getSettings().getLevelCost();
+                }
                 user.sendMessage("island.level.required-points-to-next-level",
                         "[points]", Utils.formatNumber(user, results.getPointsToNextLevel()),
-                        "[progress]", Utils.formatNumber(user, this.addon.getSettings().getLevelCost() - results.getPointsToNextLevel()),
-                        "[levelcost]", Utils.formatNumber(user, this.addon.getSettings().getLevelCost())
+                        "[progress]", Utils.formatNumber(user, results.getPointsFromCurrentLevel()),
+                        "[levelcost]", Utils.formatNumber(user, interval)
                 );
             }
             // Tell other team members


### PR DESCRIPTION
## Summary
- Fixed an issue when a non-linear function would cause negative values in the island progression.

### Example
If the `level-calc` was set to a linear function:
```YAML
level-calc: blocks / level_cost
```

The level progression calculation would work as intended.

However, if the `level-calc` was set to a non-linear function:
```YAML
level-calc: 3 * sqrt(blocks / level_cost)
```

It would produce results such as Level 3, 62/100 points. Then Level 5, -60/100 points. *See Figure 1*

This example occurred during testing when two diamond blocks were placed without any other blocks being removed. (Diamond blocks where placed on the side to prevent grass turning into dirt, thus preventing island level from dropping from that).

### Screenshots
*Figure 1.*
<img width="1010" height="713" alt="image" src="https://github.com/user-attachments/assets/d9a97b42-f01a-4cae-8591-89c961867732" />

