### PR TITLE
fix: recognize CraftEngine items in value lookups (#428)

### DIFF
--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -25,6 +25,7 @@ import world.bentobox.bentobox.api.configuration.Config;
 import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.hooks.CraftEngineHook;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
 import world.bentobox.bentobox.hooks.OraxenHook;
 import world.bentobox.bentobox.managers.RanksManager;
@@ -516,12 +517,13 @@ public class Level extends Addon {
 
     /**
      * Returns the custom-block plugin ID for an ItemStack, checking Oraxen, Nexo,
-     * and ItemsAdder in that order. Returns {@code null} when the item is not
-     * recognized as a custom block by any supported plugin.
+     * ItemsAdder, and CraftEngine in that order. Returns {@code null} when the item
+     * is not recognized as a custom block by any supported plugin.
      *
      * @param item the ItemStack to check (may be null)
      * @return a namespaced custom-block ID such as {@code "oraxen:my_block"},
-     *         {@code "nexo:my_block"}, or an ItemsAdder ID, or {@code null}
+     *         {@code "nexo:my_block"}, an ItemsAdder ID, or a CraftEngine ID
+     *         (e.g. {@code "default:my_block"}), or {@code null}
      */
     @Nullable
     public String getCustomBlockId(ItemStack item) {
@@ -547,6 +549,13 @@ public class Level extends Addon {
             Optional<String> id = ItemsAdderHook.getNamespacedId(item);
             if (id.isPresent()) {
                 return id.get();
+            }
+        }
+        // Check CraftEngine — IDs are already namespaced (e.g. "mynamespace:my_block")
+        if (isCraftEngine()) {
+            String id = CraftEngineHook.getItemId(item);
+            if (id != null) {
+                return id;
             }
         }
         return null;

--- a/src/main/java/world/bentobox/level/commands/IslandValueCommand.java
+++ b/src/main/java/world/bentobox/level/commands/IslandValueCommand.java
@@ -107,14 +107,18 @@ public class IslandValueCommand extends CompositeCommand
 
         if (value != null)
         {
+            String displayName = (material instanceof String id)
+                    ? Utils.getCustomBlockDisplayName(Utils.getCustomBlockItemStack(addon, id), id, user)
+                    : Utils.prettifyObject(material, user);
+
             Utils.sendMessage(user, user.getTranslation(this.getWorld(), "level.conversations.value", "[value]",
-                    String.valueOf(value), MATERIAL, Utils.prettifyObject(material, user)));
+                    String.valueOf(value), MATERIAL, displayName));
 
             double underWater = this.addon.getSettings().getUnderWaterMultiplier();
 
             if (underWater > 1.0) {
                 Utils.sendMessage(user, user.getTranslation(this.getWorld(), "level.conversations.success-underwater",
-                        "[value]", (underWater * value) + ""), MATERIAL, Utils.prettifyObject(material, user));
+                        "[value]", (underWater * value) + ""), MATERIAL, displayName);
             }
 
             // Show how many have been placed and how many are allowed

--- a/src/main/java/world/bentobox/level/util/Utils.java
+++ b/src/main/java/world/bentobox/level/util/Utils.java
@@ -20,6 +20,7 @@ import com.nexomc.nexo.api.NexoItems;
 
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.hooks.CraftEngineHook;
 import world.bentobox.bentobox.hooks.ItemsAdderHook;
 import world.bentobox.bentobox.hooks.LangUtilsHook;
 import world.bentobox.bentobox.hooks.OraxenHook;
@@ -226,10 +227,11 @@ public class Utils
 
     /**
      * Returns the best available ItemStack for a custom-block string ID.
-     * Checks Oraxen, Nexo, and ItemsAdder in order; returns empty when none matches.
+     * Checks Oraxen, Nexo, ItemsAdder, and CraftEngine in order; returns empty when none matches.
      *
      * @param addon the Level addon
-     * @param id    the custom block ID (e.g. "oraxen:my_block", "nexo:my_block", or an ItemsAdder ID)
+     * @param id    the custom block ID (e.g. "oraxen:my_block", "nexo:my_block", an ItemsAdder ID,
+     *              or a CraftEngine ID such as "default:my_block")
      * @return an Optional containing the representative ItemStack, or empty
      */
     public static Optional<ItemStack> getCustomBlockItemStack(Level addon, String id) {
@@ -246,12 +248,18 @@ public class Utils
         if (addon.isItemsAdder() && ItemsAdderHook.isInRegistry(id)) {
             return ItemsAdderHook.getItemStack(id);
         }
+        if (addon.isCraftEngine()) {
+            return CraftEngineHook.getItemStack(id);
+        }
         return Optional.empty();
     }
 
     /**
      * Returns the display name from an ItemStack's meta when present, otherwise falls back to
      * {@link #prettifyObject(Object, User)} on the original key.
+     * <p>
+     * Checks the legacy {@code display.Name} (used by Oraxen, Nexo, ItemsAdder) and then the
+     * modern {@code minecraft:item_name} component (used by CraftEngine and other 1.20.5+ items).
      *
      * @param itemStack the optional ItemStack (typically from a custom-block plugin)
      * @param key       the raw key used as a fallback for prettification
@@ -259,8 +267,17 @@ public class Utils
      * @return the human-readable display name
      */
     public static String getCustomBlockDisplayName(Optional<ItemStack> itemStack, String key, User user) {
-        return itemStack.filter(is -> is.getItemMeta() != null && is.getItemMeta().hasDisplayName())
-                .map(is -> is.getItemMeta().getDisplayName()).orElse(prettifyObject(key, user));
+        if (itemStack.isEmpty() || itemStack.get().getItemMeta() == null) {
+            return prettifyObject(key, user);
+        }
+        org.bukkit.inventory.meta.ItemMeta meta = itemStack.get().getItemMeta();
+        if (meta.hasDisplayName()) {
+            return meta.getDisplayName();
+        }
+        if (meta.hasItemName()) {
+            return meta.getItemName();
+        }
+        return prettifyObject(key, user);
     }
 
     public static String prettifyDescription(Object object, User user) {


### PR DESCRIPTION
Closes #428.

## Summary
- `Level.getCustomBlockId` checks CraftEngine via `CraftEngineHook.getItemId`, so a held CraftEngine custom item is mapped to its namespaced ID instead of falling back to the vanilla material (PAPER, which has no value).
- `Utils.getCustomBlockItemStack` delegates to `CraftEngineHook.getItemStack`, so the value panel renders the real custom-block icon.
- `Utils.getCustomBlockDisplayName` now also reads the modern `minecraft:item_name` component (`hasItemName`/`getItemName`) that CraftEngine uses, in addition to the legacy `display.Name` used by Oraxen, Nexo, and ItemsAdder.
- `IslandValueCommand.printValue` routes string IDs through the same `getCustomBlockItemStack` / `getCustomBlockDisplayName` path the panel already uses, so chat output shows the configured display name instead of the prettified namespaced key.

## Why
Issue #428 reports that with the new CraftEngine integration, custom blocks render as a generic paper icon labelled by the raw namespaced key, and `/is value hand` reports "no value" for held custom items. The earlier icon/name fix from #426 had no CraftEngine branches in `Utils.getCustomBlockItemStack` or `Level.getCustomBlockId`, so CraftEngine never reached those code paths.

## Dependency
Requires the BentoBox `getItemId` helper from BentoBoxWorld/BentoBox#2973. Once merged and published as a snapshot, this PR can land. (Local testing was done against a `3.15.1-SNAPSHOT-LOCAL` build of BentoBox develop + the #2973 branch.)

## Test plan
- [x] All 216 existing tests pass against locally-built BentoBox snapshot
- [x] In-game: `/is value hand` on a CraftEngine custom item now reports the configured value with the configured display name
- [x] In-game: value panel shows real CraftEngine icon and item-name (no more PAPER + prettified key)
- [ ] CI green once #2973 is merged and snapshot is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)