### PR TITLE
feat: donations-only mode — skip block scan (#430)

### DIFF
--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -275,7 +275,11 @@ public class Level extends Addon {
             new IslandLevelCommand(this, playerCmd);
             new IslandTopCommand(this, playerCmd);
             new IslandValueCommand(this, playerCmd);
-            new IslandDetailCommand(this, playerCmd);
+            // In donations-only mode, there are no scanned blocks to break down,
+            // so the detail command is not registered.
+            if (!getSettings().isDonationsOnly()) {
+                new IslandDetailCommand(this, playerCmd);
+            }
             new IslandDonateCommand(this, playerCmd);
         });
     }

--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -794,6 +794,14 @@ public class IslandLevelCalculator {
     }
 
     public void scanIsland(Pipeliner pipeliner) {
+        // In donations-only mode, skip the chunk scan entirely. tidyUp() will add
+        // the donated points and compute the level from those alone.
+        if (addon.getSettings().isDonationsOnly()) {
+            pipeliner.getInProcessQueue().remove(this);
+            this.tidyUp();
+            this.getR().complete(getResults());
+            return;
+        }
         // Scan the next chunk
         scanNextChunk().thenAccept(result -> {
             if (!Bukkit.isPrimaryThread()) {

--- a/src/main/java/world/bentobox/level/config/ConfigSettings.java
+++ b/src/main/java/world/bentobox/level/config/ConfigSettings.java
@@ -54,6 +54,17 @@ public class ConfigSettings implements ConfigObject {
     @ConfigEntry(path = "zero-new-island-levels")
     private boolean zeroNewIslandLevels = true;
 
+    @ConfigComment("")
+    @ConfigComment("Donations-only mode")
+    @ConfigComment("If true, the island block scan is skipped entirely and the island level")
+    @ConfigComment("is computed only from blocks donated via /island donate. This removes the")
+    @ConfigComment("per-recalculation CPU cost of scanning the island.")
+    @ConfigComment("The /island detail command is not registered in this mode, since there")
+    @ConfigComment("are no scanned blocks to break down. /island level still works and reports")
+    @ConfigComment("the level based on donated blocks.")
+    @ConfigEntry(path = "donations-only")
+    private boolean donationsOnly = false;
+
 
     @ConfigComment("")
     @ConfigComment("Calculate island level on login")
@@ -508,5 +519,20 @@ public class ConfigSettings implements ConfigObject {
      */
     public void setDisableItemsAdder(boolean disableItemsAdder) {
         this.disableItemsAdder = disableItemsAdder;
+    }
+
+    /**
+     * @return true if donations-only mode is enabled (block scan skipped, level
+     *         computed from donations only, /island detail disabled)
+     */
+    public boolean isDonationsOnly() {
+        return donationsOnly;
+    }
+
+    /**
+     * @param donationsOnly the donationsOnly to set
+     */
+    public void setDonationsOnly(boolean donationsOnly) {
+        this.donationsOnly = donationsOnly;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,13 +20,22 @@ concurrent-island-calcs: 1
 # If an island takes longer that this time to calculate, then the calculation will abort.
 # Generally, calculation should only take a few seconds, so if this ever triggers then something is not right.
 calculation-timeout: 5
-# 
+#
 # Zero island levels on new island or island reset
 # If true, Level will calculate the starter island's level and remove it from any future level calculations.
 # If false, the player's starter island blocks will count towards their level.
 # This will reduce CPU if false.
 zero-new-island-levels: true
-# 
+#
+# Donations-only mode
+# If true, the island block scan is skipped entirely and the island level
+# is computed only from blocks donated via /island donate. This removes the
+# per-recalculation CPU cost of scanning the island.
+# The /island detail command is not registered in this mode, since there
+# are no scanned blocks to break down. /island level still works and reports
+# the level based on donated blocks.
+donations-only: false
+#
 # Calculate island level on login
 # This silently calculates the player's island level when they login
 # This applies to all islands the player has on the server, e.g., BSkyBlock, AcidIsland

--- a/src/test/java/world/bentobox/level/LevelTest.java
+++ b/src/test/java/world/bentobox/level/LevelTest.java
@@ -247,4 +247,19 @@ class LevelTest extends CommonTestSetup {
 		assertEquals(100, s.getLevelCost());
 	}
 
+	/**
+	 * Donations-only mode must not register the IslandDetailCommand, so we expect
+	 * four player commands instead of the usual five.
+	 */
+	@Test
+	void testAllLoadedDonationsOnlySkipsDetailCommand() {
+		mockedBukkit.when(() -> Bukkit.getWorld("acidisland_world")).thenReturn(null);
+		addon.getSettings().setDonationsOnly(true);
+		addon.allLoaded();
+		// 4 player commands (level, top, value, donate) — no detail
+		verify(cmd, times(4)).getAddon();
+		// Admin command count is unchanged
+		verify(adminCmd, times(5)).getAddon();
+	}
+
 }


### PR DESCRIPTION
Closes #430.

## Summary
- New `donations-only` config option in `config.yml` (default `false`). When `true`, the per-recalculation island chunk scan is skipped entirely and the island level is computed only from blocks donated via `/island donate`.
- `IslandLevelCalculator.scanIsland` short-circuits straight to `tidyUp()` in this mode, which already reads the donated points from `LevelsManager.getDonatedPoints(island)` and applies the configured `level-calc` formula. The death penalty is still applied.
- `/island detail` is not registered in this mode (per the issue thread — there are no scanned blocks to break down). `/island level`, `/island top`, `/island value`, and `/island donate` continue to work; `/island level` reports the level based on donated blocks alone.

## Why this scope
From the issue thread:
> The donation menu provides automatic level counting, so the \"/ob level\" command is not needed […]
> I think you still need to see your level though, but it will be based on only the donated blocks. […] I agree that the detail command will not be required.

So the change keeps the rest of the player commands intact and only drops the detail command, which has no useful output when there is no block scan.

## Test plan
- [x] `mvn test` — 217/217 pass (1 new test for the gated detail command)
- [ ] In-game with `donations-only: true`: `/island level` reports a level based only on donated points; `/island detail` is not registered; `/island donate hand`/`inv` still works and updates the level
- [ ] In-game with `donations-only: false` (default): all five player commands register and the existing scan-based flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)