### PR TITLE
FIXED: Bug where max island progress would decrease when island level should be negative

### DIFF
--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -769,22 +769,34 @@ public class IslandLevelCalculator {
         }
         this.results.pointsToNextLevel.set(lo - blockAndDeathPoints);
 
-        // Binary search for points accumulated within the current level.
+        // Points accumulated within the current level.
         // Floor at initialCount when zeroing new islands to avoid negative/NaN in non-linear formulas.
         // In donations-only mode, the initial count is ignored (see calculateLevel).
         long minBlocks = addon.getSettings().isZeroNewIslandLevels() && !addon.getSettings().isDonationsOnly()
                 ? results.initialCount.get() : 0;
-        lo = Math.max(minBlocks, blockAndDeathPoints - MAX_AMOUNT);
-        hi = blockAndDeathPoints;
-        while (lo < hi) {
-            long mid = lo + (hi - lo) / 2;
-            if (calculateLevel(mid) >= currentLevel) {
-                hi = mid;
-            } else {
-                lo = mid + 1;
+        long lowerBlocks;
+        if (currentLevel == 0) {
+            // Anchor to the level-0 floor so progress goes negative when blocks drop below
+            // the starting count (e.g. 0/130 → -8/130 instead of 0/122). Searching below the
+            // floor is also unsafe: calculateLevel subtracts initialCount internally, so
+            // probing below it produces negative modifiedPoints that yield NaN (sqrt, log)
+            // or fractions that truncate to 0 — both satisfy >= 0 and would mislead a search.
+            lowerBlocks = minBlocks;
+        } else {
+            // Binary search for the smallest block count that still yields the current level.
+            lo = Math.max(minBlocks, blockAndDeathPoints - MAX_AMOUNT);
+            hi = blockAndDeathPoints;
+            while (lo < hi) {
+                long mid = lo + (hi - lo) / 2;
+                if (calculateLevel(mid) >= currentLevel) {
+                    hi = mid;
+                } else {
+                    lo = mid + 1;
+                }
             }
+            lowerBlocks = lo;
         }
-        this.results.pointsFromCurrentLevel.set(blockAndDeathPoints - lo);
+        this.results.pointsFromCurrentLevel.set(blockAndDeathPoints - lowerBlocks);
 
         // Report
         results.report = getReport();


### PR DESCRIPTION
This pull request improves the calculation of points accumulated within the current level in the `tidyUp()` method of `IslandLevelCalculator.java`. The main change is a more robust handling of level-0 islands to prevent negative progress and calculation errors, especially for new islands or when block counts drop below the starting count.

Calculation logic improvements:

* For level-0 islands, the calculation now anchors progress to the initial block count (`minBlocks`), preventing negative or misleading progress values and avoiding unsafe searches that could result in NaN or incorrect values due to the behavior of `calculateLevel` with negative inputs.
* For islands above level 0, the binary search for points from the current level remains, but the result is now consistently assigned to `lowerBlocks` for use in the points calculation. [[1]](diffhunk://#diff-1edace3f6d559fc995feeae68c26ab745967bb393f66f47f5c95f55bdd3c5216L772-R786) [[2]](diffhunk://#diff-1edace3f6d559fc995feeae68c26ab745967bb393f66f47f5c95f55bdd3c5216L787-R799)
* The assignment to `results.pointsFromCurrentLevel` is updated to use `blockAndDeathPoints - lowerBlocks`, ensuring correct progress reporting for all cases.