### PR TITLE
fix: zero new island on large protection ranges via incremental capture

### DIFF
--- a/src/main/java/world/bentobox/level/Level.java
+++ b/src/main/java/world/bentobox/level/Level.java
@@ -46,6 +46,7 @@ import world.bentobox.level.config.ConfigSettings;
 import world.bentobox.level.listeners.IslandActivitiesListeners;
 import world.bentobox.level.listeners.JoinLeaveListener;
 import world.bentobox.level.listeners.MigrationListener;
+import world.bentobox.level.listeners.NewChunkListener;
 import world.bentobox.level.requests.LevelRequestHandler;
 import world.bentobox.level.requests.TopTenRequestHandler;
 import world.bentobox.visit.VisitAddon;
@@ -154,6 +155,10 @@ public class Level extends Addon {
         registerListener(new IslandActivitiesListeners(this));
         registerListener(new JoinLeaveListener(this));
         registerListener(new MigrationListener(this));
+        // Accumulates generator block points into initialCount as new chunks
+        // are generated, so large protection ranges work with zero-new-island
+        // mode without forcing the initial scan to generate the whole area.
+        registerListener(new NewChunkListener(this));
     }
 
     private void registerGameModeCommands() {

--- a/src/main/java/world/bentobox/level/LevelsManager.java
+++ b/src/main/java/world/bentobox/level/LevelsManager.java
@@ -480,13 +480,34 @@ public class LevelsManager {
 
     /**
      * Set an initial island count
-     * 
+     *
      * @param island - the island to set.
      * @param lv     - initial island count
      */
     public void setInitialIslandCount(@NonNull Island island, long lv) {
         levelsCache.computeIfAbsent(island.getUniqueId(), IslandLevels::new).setInitialCount(lv);
         handler.saveObjectAsync(levelsCache.get(island.getUniqueId()));
+    }
+
+    /**
+     * Add a delta to the island's initial-count handicap. Used by the new-chunk
+     * listener to accumulate generator block points (sea floor, nether ceiling,
+     * etc.) into the initial count as chunks are generated during normal play.
+     * The initial count is subtracted from the live block total in the level
+     * calc, so generator blocks do not inflate the level.
+     *
+     * @param island the island
+     * @param delta  the points to add (no-op when zero)
+     */
+    public void addToInitialCount(@NonNull Island island, long delta) {
+        if (delta == 0) {
+            return;
+        }
+        // Use getInitialCount so any legacy initialLevel is migrated first.
+        long current = getInitialCount(island);
+        IslandLevels data = getLevelsData(island);
+        data.setInitialCount(current + delta);
+        handler.saveObjectAsync(data);
     }
 
     /**

--- a/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
+++ b/src/main/java/world/bentobox/level/calculators/IslandLevelCalculator.java
@@ -366,8 +366,14 @@ public class IslandLevelCalculator {
             return;
         }
         Pair<Integer, Integer> p = pairList.poll();
-        // We need to generate now all the time because some game modes are not voids
-        Util.getChunkAtAsync(world, p.x, p.z, true).thenAccept(chunk -> {
+        // For zero-island scans, do not force chunk generation. Forcing the
+        // generator for every chunk in a large protection range (e.g. 1000 →
+        // ~16k chunks/dim) blows past the calculation timeout. Generator
+        // blocks that appear later (sea floor, nether ceiling, etc.) are
+        // picked up incrementally by NewChunkListener as chunks generate
+        // during normal play. Regular scans still generate, because some game
+        // modes are not voids.
+        Util.getChunkAtAsync(world, p.x, p.z, !zeroIsland).thenAccept(chunk -> {
             if (chunk != null) {
                 chunkList.add(chunk);
                 roseStackerCheck(chunk);

--- a/src/main/java/world/bentobox/level/listeners/NewChunkListener.java
+++ b/src/main/java/world/bentobox/level/listeners/NewChunkListener.java
@@ -31,6 +31,16 @@ import world.bentobox.level.Level;
  */
 public class NewChunkListener implements Listener {
 
+    /**
+     * Snapshot of the main-thread state needed to score one chunk on a worker
+     * thread. Bundled into a record so the async scan helpers don't need to
+     * carry a dozen parameters each.
+     */
+    private record ScanContext(World world, int chunkBlockX, int chunkBlockZ, int minHeight, int maxHeight,
+            int minProtectedX, int maxProtectedX, int minProtectedZ, int maxProtectedZ,
+            int seaHeight, double underwaterMultiplier) {
+    }
+
     private final Level addon;
 
     public NewChunkListener(Level addon) {
@@ -51,29 +61,25 @@ public class NewChunkListener implements Listener {
             return;
         }
         // Use the chunk centre to look up the island that owns it.
-        Location centre = new Location(world, (chunk.getX() << 4) + 8, world.getMinHeight(),
-                (chunk.getZ() << 4) + 8);
+        // The + 8.0 keeps the addition in double arithmetic so SonarQube does not
+        // flag a theoretical int-overflow before the implicit widening.
+        Location centre = new Location(world, (chunk.getX() << 4) + 8.0, world.getMinHeight(),
+                (chunk.getZ() << 4) + 8.0);
         Island island = addon.getIslands().getIslandAt(centre).orElse(null);
         if (island == null || island.getOwner() == null) {
             return;
         }
         // Capture all main-thread state before going async.
         ChunkSnapshot snapshot = chunk.getChunkSnapshot();
-        int seaHeight = addon.getPlugin().getIWM().getSeaHeight(world);
-        double underwaterMultiplier = addon.getSettings().getUnderWaterMultiplier();
-        int minProtectedX = island.getMinProtectedX();
-        int maxProtectedX = island.getMaxProtectedX();
-        int minProtectedZ = island.getMinProtectedZ();
-        int maxProtectedZ = island.getMaxProtectedZ();
-        int minHeight = world.getMinHeight();
-        int maxHeight = world.getMaxHeight();
-        int chunkBlockX = chunk.getX() << 4;
-        int chunkBlockZ = chunk.getZ() << 4;
+        ScanContext ctx = new ScanContext(world, chunk.getX() << 4, chunk.getZ() << 4,
+                world.getMinHeight(), world.getMaxHeight(),
+                island.getMinProtectedX(), island.getMaxProtectedX(),
+                island.getMinProtectedZ(), island.getMaxProtectedZ(),
+                addon.getPlugin().getIWM().getSeaHeight(world),
+                addon.getSettings().getUnderWaterMultiplier());
 
         Bukkit.getScheduler().runTaskAsynchronously(addon.getPlugin(), () -> {
-            long total = scanSnapshot(snapshot, world, chunkBlockX, chunkBlockZ, minHeight, maxHeight,
-                    minProtectedX, maxProtectedX, minProtectedZ, maxProtectedZ, seaHeight,
-                    underwaterMultiplier);
+            long total = scanSnapshot(snapshot, ctx);
             if (total != 0L) {
                 Bukkit.getScheduler().runTask(addon.getPlugin(),
                         () -> addon.getManager().addToInitialCount(island, total));
@@ -81,37 +87,48 @@ public class NewChunkListener implements Listener {
         });
     }
 
-    private long scanSnapshot(ChunkSnapshot snapshot, World world, int chunkBlockX, int chunkBlockZ,
-            int minHeight, int maxHeight, int minProtectedX, int maxProtectedX, int minProtectedZ,
-            int maxProtectedZ, int seaHeight, double underwaterMultiplier) {
+    private long scanSnapshot(ChunkSnapshot snapshot, ScanContext ctx) {
         long total = 0L;
         for (int x = 0; x < 16; x++) {
-            int globalX = chunkBlockX + x;
-            if (globalX < minProtectedX || globalX >= maxProtectedX) {
-                continue;
-            }
-            for (int z = 0; z < 16; z++) {
-                int globalZ = chunkBlockZ + z;
-                if (globalZ < minProtectedZ || globalZ >= maxProtectedZ) {
-                    continue;
-                }
-                for (int y = minHeight; y < maxHeight; y++) {
-                    Material mat = snapshot.getBlockType(x, y, z);
-                    if (mat.isAir()) {
-                        continue;
-                    }
-                    Integer value = addon.getBlockConfig().getValue(world, mat);
-                    if (value == null || value == 0) {
-                        continue;
-                    }
-                    if (seaHeight > 0 && y <= seaHeight) {
-                        total += (long) (value * underwaterMultiplier);
-                    } else {
-                        total += value;
-                    }
-                }
+            int globalX = ctx.chunkBlockX + x;
+            if (globalX >= ctx.minProtectedX && globalX < ctx.maxProtectedX) {
+                total += scanRow(snapshot, x, ctx);
             }
         }
         return total;
+    }
+
+    private long scanRow(ChunkSnapshot snapshot, int x, ScanContext ctx) {
+        long total = 0L;
+        for (int z = 0; z < 16; z++) {
+            int globalZ = ctx.chunkBlockZ + z;
+            if (globalZ >= ctx.minProtectedZ && globalZ < ctx.maxProtectedZ) {
+                total += scanColumn(snapshot, x, z, ctx);
+            }
+        }
+        return total;
+    }
+
+    private long scanColumn(ChunkSnapshot snapshot, int x, int z, ScanContext ctx) {
+        long total = 0L;
+        for (int y = ctx.minHeight; y < ctx.maxHeight; y++) {
+            total += valueAt(snapshot, x, y, z, ctx);
+        }
+        return total;
+    }
+
+    private long valueAt(ChunkSnapshot snapshot, int x, int y, int z, ScanContext ctx) {
+        Material mat = snapshot.getBlockType(x, y, z);
+        if (mat.isAir()) {
+            return 0L;
+        }
+        Integer value = addon.getBlockConfig().getValue(ctx.world, mat);
+        if (value == null || value == 0) {
+            return 0L;
+        }
+        if (ctx.seaHeight > 0 && y <= ctx.seaHeight) {
+            return (long) (value * ctx.underwaterMultiplier);
+        }
+        return value;
     }
 }

--- a/src/main/java/world/bentobox/level/listeners/NewChunkListener.java
+++ b/src/main/java/world/bentobox/level/listeners/NewChunkListener.java
@@ -1,0 +1,117 @@
+package world.bentobox.level.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.level.Level;
+
+/**
+ * Listens for freshly-generated chunks inside an island's protected area and
+ * adds the chunk's generator block points to the island's initial-count
+ * handicap.
+ * <p>
+ * Together with the {@code gen=false} initial zero scan in
+ * {@link world.bentobox.level.calculators.IslandLevelCalculator}, this lets
+ * zero-new-island-level mode work on islands with very large protection
+ * ranges. The initial scan only records what is already generated at island
+ * creation time (typically just the schematic chunks). As the player
+ * explores and new chunks are generated, this listener accumulates their
+ * generator block points into the initial count so they cancel out of the
+ * regular level calc — players only get credit for blocks they actually
+ * place.
+ */
+public class NewChunkListener implements Listener {
+
+    private final Level addon;
+
+    public NewChunkListener(Level addon) {
+        this.addon = addon;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChunkLoad(ChunkLoadEvent e) {
+        if (!e.isNewChunk()) {
+            return;
+        }
+        if (!addon.getSettings().isZeroNewIslandLevels()) {
+            return;
+        }
+        Chunk chunk = e.getChunk();
+        World world = chunk.getWorld();
+        if (!addon.isRegisteredGameModeWorld(world)) {
+            return;
+        }
+        // Use the chunk centre to look up the island that owns it.
+        Location centre = new Location(world, (chunk.getX() << 4) + 8, world.getMinHeight(),
+                (chunk.getZ() << 4) + 8);
+        Island island = addon.getIslands().getIslandAt(centre).orElse(null);
+        if (island == null || island.getOwner() == null) {
+            return;
+        }
+        // Capture all main-thread state before going async.
+        ChunkSnapshot snapshot = chunk.getChunkSnapshot();
+        int seaHeight = addon.getPlugin().getIWM().getSeaHeight(world);
+        double underwaterMultiplier = addon.getSettings().getUnderWaterMultiplier();
+        int minProtectedX = island.getMinProtectedX();
+        int maxProtectedX = island.getMaxProtectedX();
+        int minProtectedZ = island.getMinProtectedZ();
+        int maxProtectedZ = island.getMaxProtectedZ();
+        int minHeight = world.getMinHeight();
+        int maxHeight = world.getMaxHeight();
+        int chunkBlockX = chunk.getX() << 4;
+        int chunkBlockZ = chunk.getZ() << 4;
+
+        Bukkit.getScheduler().runTaskAsynchronously(addon.getPlugin(), () -> {
+            long total = scanSnapshot(snapshot, world, chunkBlockX, chunkBlockZ, minHeight, maxHeight,
+                    minProtectedX, maxProtectedX, minProtectedZ, maxProtectedZ, seaHeight,
+                    underwaterMultiplier);
+            if (total != 0L) {
+                Bukkit.getScheduler().runTask(addon.getPlugin(),
+                        () -> addon.getManager().addToInitialCount(island, total));
+            }
+        });
+    }
+
+    private long scanSnapshot(ChunkSnapshot snapshot, World world, int chunkBlockX, int chunkBlockZ,
+            int minHeight, int maxHeight, int minProtectedX, int maxProtectedX, int minProtectedZ,
+            int maxProtectedZ, int seaHeight, double underwaterMultiplier) {
+        long total = 0L;
+        for (int x = 0; x < 16; x++) {
+            int globalX = chunkBlockX + x;
+            if (globalX < minProtectedX || globalX >= maxProtectedX) {
+                continue;
+            }
+            for (int z = 0; z < 16; z++) {
+                int globalZ = chunkBlockZ + z;
+                if (globalZ < minProtectedZ || globalZ >= maxProtectedZ) {
+                    continue;
+                }
+                for (int y = minHeight; y < maxHeight; y++) {
+                    Material mat = snapshot.getBlockType(x, y, z);
+                    if (mat.isAir()) {
+                        continue;
+                    }
+                    Integer value = addon.getBlockConfig().getValue(world, mat);
+                    if (value == null || value == 0) {
+                        continue;
+                    }
+                    if (seaHeight > 0 && y <= seaHeight) {
+                        total += (long) (value * underwaterMultiplier);
+                    } else {
+                        total += value;
+                    }
+                }
+            }
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
## Summary
- Switch the zero-island scan to `gen=false` so it only counts chunks that exist at zero time (typically just the schematic). Fixes the 5-minute timeout that fires when `zero-new-island-levels` is on and the protection range is large (e.g. 1000 → ~16k chunks/dim, all needing generation on a fresh world).
- Add `NewChunkListener` to accumulate generator block points (sea floor, nether ceiling, etc.) into `initialCount` lazily as chunks are generated during normal play. Regular level calcs subtract the now-incrementally-grown `initialCount`, so generator blocks always cancel out — players only get credit for their own placements.
- Add `LevelsManager.addToInitialCount(island, delta)` to support the listener (also migrates any legacy `initialLevel`).

## Repro the original bug
1. Fresh world / server / DB.
2. Set island range and protection range to 1000.
3. `/is` to create an island.

Before: console shows `Zeroing island level …` then `Level calculation timed out after 5m … Island level was being zeroed.` and `initialCount` is never set.
After: zero scan completes in seconds (only schematic chunks); generator chunks roll into `initialCount` as the player explores.

## Trade-off
Per-block-type limits apply within a single scan but not across the listener's incremental additions. For aggressively-limited block types (e.g. cobblestone capped at 10k) generated heavily by terrain, the math can drift slightly. If that becomes an issue, the fix is to store per-block-type initial counts and apply limits at calc time — happy to follow up.

## Test plan
- [ ] Build/tests pass locally (`mvn test`)
- [ ] BSkyBlock: fresh world, range 1000, `/is` — zero scan completes quickly; level after building reflects only placed blocks
- [ ] AcidIsland-style game mode with sea floor: explore beyond schematic — newly generated sea floor does not inflate level
- [ ] Legacy island (already zeroed pre-upgrade): no double-counting on chunk loads (no `isNewChunk` events fire for already-generated chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)