### PR TITLE
ci: align CurseForge/Hangar game versions with Modrinth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,10 @@ jobs:
     uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: "Level"           # blank = skip Hangar
+      hangar_slug: "Level"
       curseforge_id: "1514824"
-      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      # Keep in sync with the game-versions list in modrinth-publish.yml
+      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
     secrets:
       HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}


### PR DESCRIPTION
Addresses review issue 6 from the [2.28.0 release review](https://github.com/BentoBoxWorld/Level/pull/441).

- Drop `26.2` from `publish.yml`'s `game_versions` so CurseForge/Hangar claim the same supported versions as `modrinth-publish.yml` (which stops at 26.1.2). If 26.2 is actually supported, the right fix is to add it to **both** lists instead — flagging in case that was the intent.
- Remove the stale `# blank = skip Hangar` copy-paste comment beside the non-blank `hangar_slug`.
- Add the missing newline at end of file, and a cross-reference comment so the two lists stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6f59pxCkwS8QXtJSe1nq6