### PR TITLE
fix: don't queue duplicate search conversations in value GUI

### DIFF
--- a/src/main/java/world/bentobox/level/util/ConversationUtils.java
+++ b/src/main/java/world/bentobox/level/util/ConversationUtils.java
@@ -43,6 +43,16 @@ public class ConversationUtils
             @NonNull String question,
             @Nullable String successMessage)
     {
+        if (user.getPlayer().isConversing())
+        {
+            // Bukkit queues conversations per player, so starting another one here would
+            // stack prompts that later replay as cancel/prompt spam (#451). Repeat the
+            // question for the pending conversation instead.
+            user.closeInventory();
+            user.getPlayer().sendRawMessage(user.getTranslation("level.conversations.prefix") + question);
+            return;
+        }
+
         // Text input message.
         StringPrompt stringPrompt = new StringPrompt()
         {

--- a/src/test/java/world/bentobox/level/util/ConversationUtilsTest.java
+++ b/src/test/java/world/bentobox/level/util/ConversationUtilsTest.java
@@ -1,0 +1,62 @@
+package world.bentobox.level.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+
+import org.bukkit.conversations.Conversation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.level.CommonTestSetup;
+
+/**
+ * Tests for {@link ConversationUtils}.
+ */
+class ConversationUtilsTest extends CommonTestSetup {
+
+    private User user;
+
+    @Override
+    @BeforeEach
+    protected void setUp() throws Exception {
+        super.setUp();
+        // The conversation timeout canceller starts a scheduler timer on build.
+        when(plugin.getServer()).thenReturn(server);
+        user = User.getInstance(p);
+    }
+
+    /**
+     * A player with no active conversation should get a new one.
+     */
+    @Test
+    void testCreateStringInputStartsConversation() {
+        when(p.isConversing()).thenReturn(false);
+
+        Consumer<String> consumer = value -> {};
+        ConversationUtils.createStringInput(consumer, user, "question?", "done");
+
+        verify(p).beginConversation(any(Conversation.class));
+    }
+
+    /**
+     * Clicking the search button while a conversation is already pending must not
+     * queue a second conversation (#451) — it should just repeat the question.
+     */
+    @Test
+    void testCreateStringInputDoesNotQueueSecondConversation() {
+        when(p.isConversing()).thenReturn(true);
+
+        Consumer<String> consumer = value -> {};
+        ConversationUtils.createStringInput(consumer, user, "question?", "done");
+
+        verify(p, never()).beginConversation(any(Conversation.class));
+        verify(p).closeInventory();
+        verify(p).sendRawMessage(anyString());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #451.

Bukkit queues conversations per player, so every click on the value panel's search button began another 90-second conversation. If the first prompt wasn't visible (e.g. a chat-managing plugin like CMI swallowed it), players clicked the button repeatedly, stacking conversations that later replayed as alternating `Conversation cancelled!` / `Please enter a search value` spam with the GUI re-opening each time.

## Fix
`ConversationUtils.createStringInput` now checks `Player#isConversing()` first. If a conversation is already pending, it closes the GUI and repeats the question (with the usual prefix) instead of queueing a second conversation — so the pending prompt still works and no spam accumulates.

## Testing
- New `ConversationUtilsTest`: verifies a conversation starts normally when none is pending, and that no second conversation is begun (question is re-sent instead) when one is already active.
- Full suite passes (246 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSvRYW3Rgh6Vgvx62QRYE1